### PR TITLE
Core is exported as a resource, and use bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,36 +470,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce81edaca6167d1f78da026afa92d7ff957a80aa82a79076e11cd34cde20165"
+checksum = "0ae7b60ec3fd7162427d3b3801520a1908bef7c035b52983cd3ca11b8e7deb51"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0d51e12f958551165969c6e8767e1e461729f6c1ccae923b0ba1d5cbcbbbf8"
+checksum = "6511c200fed36452697b4b6b161eae57d917a2044e6333b1c1389ed63ccadeee"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41294c755094d2c8a514cea903039742474423f2e91601332eab5f4094f76333"
+checksum = "5f7086a645aa58bae979312f64e3029ac760ac1b577f5cd2417844842a2ca07f"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb6f5d0df5bd0d02c63ec48e8f2e38a176b123f59e084f22caf89a0d0593e7e"
+checksum = "5225b4dec45f3f3dbf383f12560fac5ce8d780f399893607e21406e12e77f491"
 dependencies = [
  "serde",
  "serde_derive",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e543cdb278b7c15f739021cf880ee1808c68fa2402febb87edb9307f552c8fec"
+checksum = "858fb3331e53492a95979378d6df5208dd1d0d315f19c052be8115f4efc888e0"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -529,14 +529,14 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-math",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f979c75cfd712dbc754799dfe4a4d0db7a51defc2e36d006b27a8a63e018eece"
+checksum = "456715b9d5f12398f156d5081096e7b5d039f01b9ecc49790a011c8e43e65b5f"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -546,24 +546,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f36e74ba4033490587a47952f74390cb7d4f1fc1fa28ace50564e491f1e38f"
+checksum = "0306041099499833f167a0ddb707e1e54100f1a84eab5631bc3dad249708f482"
 
 [[package]]
 name = "cranelift-control"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6671962c7d65b9a7ad038cd92da6784744d8a9ecf8ded8bb9a1f7046dbe2ccf"
+checksum = "1672945e1f9afc2297f49c92623f5eabc64398e2cb0d824f8f72a2db2df5af23"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee832f8329fa87c5df6c1d64a8506a58031e6f8a190d9b21b1900272a4dbb47d"
+checksum = "aa3cd55eb5f3825b9ae5de1530887907360a6334caccdc124c52f6d75246c98a"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7bc17aa3277214eab4b63a03544b1b46962154012b751c9f14c2a5419c6471"
+checksum = "781f9905f8139b8de22987b66b522b416fe63eb76d823f0b3a8c02c8fd9500c7"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -584,15 +584,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff02dcecae2e7e9c61b713f1fb46eabecdca9f55b49f99859ceb1a3e7f4a9cb"
+checksum = "a05337a2b02c3df00b4dd9a263a027a07b3dff49f61f7da3b5d195c21eaa633d"
 
 [[package]]
 name = "cranelift-native"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f76fd681f35bdf17be9c3e516b9acc0c7bd61b81faf95496decd8e0000979c"
+checksum = "2eee7a496dd66380082c9c5b6f2d5fa149cec0ec383feec5caf079ca2b3671c2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.121.2"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3d9071bc5ee5573e723d9d84a45b7025a29e8f2c5ad81b3b9d0293129541d9"
+checksum = "b530783809a55cb68d070e0de60cfbb3db0dc94c8850dd5725411422bedcf6bb"
 
 [[package]]
 name = "crc32fast"
@@ -1920,15 +1920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
-name = "psm"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "publicsuffix"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,21 +1931,21 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "34.0.2"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14280b69a9cbb6ada02a7aa5f7b3f1b72d1043b5bc9336990b700525dea6e3"
+checksum = "b89c4319786b16c1a6a38ee04788d32c669b61ba4b69da2162c868c18be99c1b"
 dependencies = [
  "cranelift-bitset",
  "log",
  "pulley-macros",
- "wasmtime-math",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
 name = "pulley-macros"
-version = "34.0.2"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f1be746801280af4c96c4407b5fd1d09cfa53ab27ba0ac7dd8f207e7bbf83"
+checksum = "938543690519c20c3a480d20a8efcc8e69abeb44093ab1df4e7c1f81f26c677a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3121,22 +3112,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.233.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.235.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3154,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.233.0"
+version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
+checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags",
  "hashbrown",
@@ -3166,32 +3147,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
+name = "wasmprinter"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
-dependencies = [
- "bitflags",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.233.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf8e5b732895c99b21aa615f1b73352e51bbe2b2cb6c87eae7f990d07c1ac18"
+checksum = "75aa8e9076de6b9544e6dab4badada518cca0bf4966d35b131bbd057aed8fa0a"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.233.0",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "34.0.2"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec10e50038f22ab407fdd8708120b8feed3450a02618efcf26ca47e82122927d"
+checksum = "b6fe976922a16af3b0d67172c473d1fd4f1aa5d0af9c8ba6538c741f3af686f4"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3213,7 +3183,6 @@ dependencies = [
  "object",
  "once_cell",
  "postcard",
- "psm",
  "pulley-interpreter",
  "rayon",
  "rustix 1.0.7",
@@ -3224,107 +3193,31 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "trait-variant",
- "wasm-encoder 0.233.0",
- "wasmparser 0.233.0",
- "wasmtime-asm-macros",
- "wasmtime-cache",
- "wasmtime-component-macro",
- "wasmtime-component-util",
- "wasmtime-cranelift",
+ "wasm-encoder",
+ "wasmparser",
  "wasmtime-environ",
- "wasmtime-fiber",
- "wasmtime-jit-debug",
- "wasmtime-jit-icache-coherence",
- "wasmtime-math",
- "wasmtime-slab",
- "wasmtime-versioned-export-macros",
- "wasmtime-winch",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "wasmtime-asm-macros"
-version = "34.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d379cda46d6fd18619e282a75fbb09b70b3d0f166b605f45b4059dfaf9dc6ce"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "wasmtime-cache"
-version = "34.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f421723a7736c0767ceb422afef69b41526864bd0f026e0f49bb2bde7168f9a6"
-dependencies = [
- "anyhow",
- "base64",
- "directories-next",
- "log",
- "postcard",
- "rustix 1.0.7",
- "serde",
- "serde_derive",
- "sha2",
- "toml",
- "windows-sys 0.59.0",
- "zstd",
-]
-
-[[package]]
-name = "wasmtime-component-macro"
-version = "34.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b08be093e0a876da45f79070c2ada4656f2785eb77c01b86ce60be3153920a5"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser",
-]
-
-[[package]]
-name = "wasmtime-component-util"
-version = "34.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0451ce0dd94a33d0dbd57934ce666a04c2753a5262ca2bc84cf6a67cf5303dc"
-
-[[package]]
-name = "wasmtime-cranelift"
-version = "34.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15aa836683d7398f13f2f26bbe74c404ceaba66b6bbb96700d6b7f91bec90e03"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "gimli",
- "itertools 0.14.0",
- "log",
- "object",
- "pulley-interpreter",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.12",
- "wasmparser 0.233.0",
- "wasmtime-environ",
- "wasmtime-math",
- "wasmtime-versioned-export-macros",
-]
-
-[[package]]
 name = "wasmtime-environ"
-version = "34.0.2"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317081a0cbbb1f749d348b262575608fc082d47ab11b6247bbe9163eeb955777"
+checksum = "44b6264a78d806924abbc76bbc75eac24976bc83bdfb938e5074ae551242436f"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -3341,45 +3234,122 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.233.0",
- "wasmparser 0.233.0",
+ "wasm-encoder",
+ "wasmparser",
  "wasmprinter",
- "wasmtime-component-util",
+ "wasmtime-internal-component-util",
 ]
 
 [[package]]
-name = "wasmtime-fiber"
-version = "34.0.2"
+name = "wasmtime-internal-asm-macros"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6763b33eceefc443f6477d84dc8751df5f23d280d7e01f28339fa3ec4b00ff13"
+checksum = "6775a9b516559716e5710e95a8014ca0adcc81e5bf4d3ad7899d89ae40094d1a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e33ad4bd120f3b1c77d6d0dcdce0de8239555495befcda89393a40ba5e324"
+dependencies = [
+ "anyhow",
+ "base64",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 1.0.7",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3d098205e405e6b5ced06c1815621b823464b6ea289eaafe494139b0aee287"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219252067216242ed2b32665611b0ee356d6e92cbb897ecb9a10cae0b97bdeca"
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec9ad7565e6a8de7cb95484e230ff689db74a4a085219e0da0cbd637a29c01c"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.12",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b636ff8b220ebaf29dfe3b23770e4b2bad317b9683e3bf7345e162387385b39"
 dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
  "libc",
  "rustix 1.0.7",
- "wasmtime-asm-macros",
- "wasmtime-versioned-export-macros",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "wasmtime-jit-debug"
-version = "34.0.2"
+name = "wasmtime-internal-jit-debug"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f935b198c58d3f85b6f8d2fedcbaf71e6f41dee3a8278d60cbe9326b82ac91aa"
+checksum = "61d8693995ab3df48e88777b6ee3b2f441f2c4f895ab938996cdac3db26f256c"
 dependencies = [
  "cc",
  "object",
  "rustix 1.0.7",
- "wasmtime-versioned-export-macros",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "34.0.2"
+name = "wasmtime-internal-jit-icache-coherence"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea6b740d1a35f2cebfe88e013ac8a4a84ff8dabc3a392df920abf554e871cf2"
+checksum = "4417e06b7f80baff87d9770852c757a39b8d7f11d78b2620ca992b8725f16f50"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3388,25 +3358,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-math"
-version = "34.0.2"
+name = "wasmtime-internal-math"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fa317691aedc64aae3a86b3d786e4b2b0007bc0b56e0b6098b8b5a85ab2134"
+checksum = "7710d5c4ecdaa772927fd11e5dc30a9a62d1fc8fe933e11ad5576ad596ab6612"
 dependencies = [
  "libm",
 ]
 
 [[package]]
-name = "wasmtime-slab"
-version = "34.0.2"
+name = "wasmtime-internal-slab"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a06819d24370273021054b50589e3078e7f5cfac15515e58b3fbbebf5e5b39"
+checksum = "e6ab22fabe1eed27ab01fd47cd89deacf43ad222ed7fd169ba6f4dd1fbddc53b"
 
 [[package]]
-name = "wasmtime-versioned-export-macros"
-version = "34.0.2"
+name = "wasmtime-internal-unwinder"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca100ed168ffc9b37aefc07a5be440645eab612a2ff6e2ff884e8cc3740e666"
+checksum = "307708f302f5dcf19c1bbbfb3d9f2cbc837dd18088a7988747b043a46ba38ecc"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342b0466f92b7217a4de9e114175fedee1907028567d2548bcd42f71a8b5b016"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3414,10 +3397,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-wasi"
-version = "34.0.2"
+name = "wasmtime-internal-winch"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb691e92f81f339a215c6fb78f10fb9c03886a34995eba84f14d6aa846b72161"
+checksum = "2012e7384c25b91aab2f1b6a1e1cbab9d0f199bbea06cc873597a3f047f05730"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae057d44a5b60e6ec529b0c21809a9d1fc92e91ef6e0f6771ed11dd02a94a08"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d252bc54438b6b979320dc48fe8328429761aaef62cee12a848b0389b1f255c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3446,44 +3458,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "34.0.2"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5703fe2988cf503431c11989bec85bda910077925c232aeaf8d52c408fec48c5"
+checksum = "7b2664b7dabe650a102559ae49108fb00f884f319aadefcf20806ab5f2dbd535"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "futures",
  "wasmtime",
-]
-
-[[package]]
-name = "wasmtime-winch"
-version = "34.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595f51430606a7b5578f34e0d7c73dca52a22ed24756f2ba9d4d0c1bde8631af"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "object",
- "target-lexicon",
- "wasmparser 0.233.0",
- "wasmtime-cranelift",
- "wasmtime-environ",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
-version = "34.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233fdcb96f9097be697319ba647ef42bdbdb40e89f04c8ae3713103813b5b793"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "wit-parser",
 ]
 
 [[package]]
@@ -3505,7 +3488,7 @@ dependencies = [
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.235.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -3560,9 +3543,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "34.0.2"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61d3bcb6a981233e8b774738f4495ad2c724a0d73ac626f373944e9ba1e3101"
+checksum = "fc3ea480ce117a35b61e466e4f77422f2b29f744400e05de3ad87d73b8a1877c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3575,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "34.0.2"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7f9816357d0d2bd1c0af68b6e302013152dfdeef4b6a488de87dc2026ed6fa"
+checksum = "cec945b902cacd960fe5d441b60146b24639d81b887451a30bf86824a8185d79"
 dependencies = [
  "anyhow",
  "heck",
@@ -3589,9 +3572,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "34.0.2"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e215597862a78dc57fb6988bd09b76af8e632ca4cb74bc26fe3ab129b8cb3b9"
+checksum = "f5872fbe512b73acd514e7ef5bd5aee0ff951a12c1fed0293e1f7992de30df9f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3632,9 +3615,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "34.0.2"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf007d7940f62127ce4f33a8aa92dadedfdc78c3860a057e06c8c24e26e180d"
+checksum = "839a334ef7c62d8368dbd427e767a6fbb1ba08cc12ecce19cbb666c10613b585"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",
@@ -3644,10 +3627,10 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.12",
- "wasmparser 0.233.0",
- "wasmtime-cranelift",
+ "wasmparser",
  "wasmtime-environ",
- "wasmtime-math",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -3894,9 +3877,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.233.0"
+version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22f1cd55247a2e616870b619766e9522df36b7abafbb29bbeb34b7a9da7e9f0"
+checksum = "0a1f95a87d03a33e259af286b857a95911eb46236a0f726cbaec1227b3dfc67a"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -3907,7 +3890,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.233.0",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 thiserror = "2.0.12"
 tokio = { version = "1.46.1", features = ["full"] }
-wasmtime = "34.0.2"
-wasmtime-wasi = "34.0.2"
+wasmtime = "35.0.0"
+wasmtime-wasi = "35.0.0"

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -1,5 +1,3 @@
-use std::string::String;
-
 use crux_core::{Command, macros::effect};
 
 use crate::core::capabilities::{
@@ -57,10 +55,8 @@ impl crux_core::App for App {
             Event::Update(request) => call_update(request.data).then_send(Event::GotUpdate),
             Event::Resolve(request) => call_resolve(request).then_send(Event::GotResolve),
             Event::View(_) => call_view().then_send(Event::GotView),
-            Event::GotSchema(SchemaResponse(result)) => {
-                render::render(result.map(String::into_bytes))
-            }
-            Event::GotUpdate(UpdateResponse(result))
+            Event::GotSchema(SchemaResponse(result))
+            | Event::GotUpdate(UpdateResponse(result))
             | Event::GotResolve(ResolveResponse(result))
             | Event::GotView(ViewResponse(result)) => render::render(result),
         }

--- a/src/core/capabilities/schema.rs
+++ b/src/core/capabilities/schema.rs
@@ -4,7 +4,7 @@ use crate::Result;
 
 pub struct SchemaRequest;
 
-pub struct SchemaResponse(pub Result<String>);
+pub struct SchemaResponse(pub Result<Vec<u8>>);
 
 impl Operation for SchemaRequest {
     type Output = SchemaResponse;

--- a/src/shell/host.rs
+++ b/src/shell/host.rs
@@ -7,9 +7,13 @@ use std::{
 use anyhow::{Result, anyhow, bail};
 use wasmtime::{
     Engine, Store,
-    component::{Component, Linker, ResourceTable, TypedFunc},
+    component::{Component, Linker, ResourceAny, ResourceTable, bindgen},
 };
+
+use self::exports::crux::shared_lib::core::Guest;
 use wasmtime_wasi::p2::{IoView, WasiCtx, WasiCtxBuilder, WasiView, add_to_linker_sync};
+
+bindgen!();
 
 pub struct ComponentRunStates {
     pub wasi_ctx: WasiCtx,
@@ -28,16 +32,11 @@ impl WasiView for ComponentRunStates {
     }
 }
 
-type Bytes = Vec<u8>;
-
 #[derive(Default)]
-#[allow(clippy::type_complexity)]
 pub struct Host {
     store: Arc<Mutex<Option<Store<ComponentRunStates>>>>,
-    schema: Option<TypedFunc<(), (String,)>>,
-    update: Option<TypedFunc<(Bytes,), (Result<Bytes, String>,)>>,
-    resolve: Option<TypedFunc<(u32, Bytes), (Result<Bytes, String>,)>>,
-    view: Option<TypedFunc<(), (Result<Bytes, String>,)>>,
+    shared: Option<Shared>,
+    resource: Option<ResourceAny>,
 }
 
 impl Host {
@@ -55,98 +54,70 @@ impl Host {
 
         let file = PathBuf::from(env::var("CRUX_COMPONENT")?);
         let component = Component::from_file(&engine, file)?;
-        let instance = linker.instantiate(&mut store, &component)?;
 
-        if let Some(func) = instance.get_func(&mut store, "schema") {
-            self.schema = Some(func.typed::<(), (String,)>(&store)?);
-        } else {
-            bail!("schema function not found");
-        }
+        // Use the generated bindings to instantiate the component
+        let shared = Shared::instantiate(&mut store, &component, &linker)?;
 
-        if let Some(func) = instance.get_func(&mut store, "update") {
-            self.update = Some(func.typed::<(Bytes,), (Result<Bytes, String>,)>(&store)?);
-        } else {
-            bail!("update function not found");
-        }
+        // Create a new instance of the exported resource
+        let resource = shared
+            .crux_shared_lib_core()
+            .instance()
+            .call_constructor(&mut store)?;
 
-        if let Some(func) = instance.get_func(&mut store, "resolve") {
-            self.resolve = Some(func.typed::<(u32, Bytes), (Result<Bytes, String>,)>(&store)?);
-        } else {
-            bail!("resolve function not found");
-        }
-
-        if let Some(func) = instance.get_func(&mut store, "view") {
-            self.view = Some(func.typed::<(), (Result<Bytes, String>,)>(&store)?);
-        } else {
-            bail!("view function not found");
-        }
-
+        self.shared = Some(shared);
+        self.resource = Some(resource);
         self.store = Arc::new(Mutex::new(Some(store)));
 
         Ok(())
     }
 
+    fn with_guest<T, F>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&Guest, &mut Store<ComponentRunStates>, ResourceAny) -> Result<T>,
+    {
+        let Some(shared) = &self.shared else {
+            bail!("component not loaded");
+        };
+        let Some(resource) = &self.resource else {
+            bail!("no instance created");
+        };
+
+        let mut store = self.store.lock().expect("failed to lock store");
+        let Some(store) = store.as_mut() else {
+            bail!("no store");
+        };
+
+        f(shared.crux_shared_lib_core(), store, *resource)
+    }
+
     pub fn schema(&self) -> Result<String> {
-        let Some(schema) = self.schema else {
-            bail!("no schema function");
-        };
-
-        let mut store = self.store.lock().expect("failed to lock store");
-        let Some(mut store) = store.as_mut() else {
-            bail!("no store");
-        };
-
-        let (data,) = schema.call(&mut store, ())?;
-        schema.post_return(&mut store)?;
-
-        Ok(data)
+        self.with_guest(|guest, store, resource| guest.instance().call_schema(store, resource))
     }
 
-    pub fn update(&self, data: Vec<u8>) -> Result<Vec<u8>> {
-        let Some(update) = self.update else {
-            bail!("no update function");
-        };
-
-        let mut store = self.store.lock().expect("failed to lock store");
-        let Some(mut store) = store.as_mut() else {
-            bail!("no store");
-        };
-
-        let (data,) = update.call(&mut store, (data,))?;
-        update.post_return(&mut store)?;
-
-        data.map_err(|e| anyhow!("bridge error: {e}"))
+    pub fn update(&self, data: &[u8]) -> Result<Vec<u8>> {
+        self.with_guest(|guest, store, resource| {
+            guest
+                .instance()
+                .call_update(store, resource, data)?
+                .map_err(|e| anyhow!("bridge error: {e}"))
+        })
     }
 
-    pub fn resolve(&self, effect_id: u32, data: Vec<u8>) -> Result<Vec<u8>> {
-        let Some(resolve) = self.resolve else {
-            bail!("no update function");
-        };
-
-        let mut store = self.store.lock().expect("failed to lock store");
-        let Some(mut store) = store.as_mut() else {
-            bail!("no store");
-        };
-
-        let (data,) = resolve.call(&mut store, (effect_id, data))?;
-        resolve.post_return(&mut store)?;
-
-        data.map_err(|e| anyhow!("bridge error: {e}"))
+    pub fn resolve(&self, effect_id: u32, data: &[u8]) -> Result<Vec<u8>> {
+        self.with_guest(|guest, store, resource| {
+            guest
+                .instance()
+                .call_resolve(store, resource, effect_id, data)?
+                .map_err(|e| anyhow!("bridge error: {e}"))
+        })
     }
 
     pub fn view(&self) -> Result<Vec<u8>> {
-        let Some(view) = &self.view else {
-            bail!("no view function");
-        };
-
-        let mut store = self.store.lock().expect("failed to lock store");
-        let Some(mut store) = store.as_mut() else {
-            bail!("no store");
-        };
-
-        let (data,) = view.call(&mut store, ())?;
-        view.post_return(&mut store)?;
-
-        data.map_err(|e| anyhow!("bridge error: {e}"))
+        self.with_guest(|guest, store, resource| {
+            guest
+                .instance()
+                .call_view(store, resource)?
+                .map_err(|e| anyhow!("bridge error: {e}"))
+        })
     }
 }

--- a/wit/core.wit
+++ b/wit/core.wit
@@ -1,0 +1,11 @@
+package crux:shared-lib;
+
+interface core {
+    resource instance {
+        constructor();
+        update: func(data: list<u8>) -> result<list<u8>, string>;
+        resolve: func(effect-id: u32, data: list<u8>) -> result<list<u8>, string>;
+        view: func() -> result<list<u8>, string>;
+        schema: func() -> string;
+    }
+}

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,0 +1,5 @@
+package crux:shared-lib;
+
+world shared {
+    export core;
+}

--- a/x.rs
+++ b/x.rs
@@ -1,0 +1,2762 @@
+#![feature(prelude_import)]
+#[prelude_import]
+use std::prelude::rust_2024::*;
+#[macro_use]
+extern crate std;
+use rust_mcp_sdk::{
+    McpServer, StdioTransport, TransportOptions, error::SdkResult,
+    mcp_server::server_runtime,
+    schema::{
+        Implementation, InitializeResult, LATEST_PROTOCOL_VERSION, ServerCapabilities,
+        ServerCapabilitiesTools,
+    },
+};
+use crate::{event_loop::Core, shell::{host::Host, mcp::handler::MyServerHandler}};
+mod core {
+    pub mod app {
+        use crux_core::{Command, macros::effect};
+        use crate::core::capabilities::{
+            render::{self, RenderRequest},
+            resolve::{ResolveRequest, ResolveResponse, call_resolve},
+            schema::{SchemaRequest, SchemaResponse, get_schema},
+            update::{UpdateRequest, UpdateResponse, call_update},
+            view::{ViewRequest, ViewResponse, call_view},
+        };
+        pub struct Model;
+        #[automatically_derived]
+        impl ::core::default::Default for Model {
+            #[inline]
+            fn default() -> Model {
+                Model {}
+            }
+        }
+        pub enum Event {
+            Schema(SchemaRequest),
+            Update(UpdateRequest),
+            Resolve(ResolveRequest),
+            View(ViewRequest),
+            GotSchema(SchemaResponse),
+            GotUpdate(UpdateResponse),
+            GotResolve(ResolveResponse),
+            GotView(ViewResponse),
+        }
+        pub enum Effect {
+            Schema(::crux_core::Request<SchemaRequest>),
+            Update(::crux_core::Request<UpdateRequest>),
+            Resolve(::crux_core::Request<ResolveRequest>),
+            View(::crux_core::Request<ViewRequest>),
+            Render(::crux_core::Request<RenderRequest>),
+        }
+        impl crux_core::Effect for Effect {}
+        impl From<::crux_core::Request<SchemaRequest>> for Effect {
+            fn from(value: ::crux_core::Request<SchemaRequest>) -> Self {
+                Self::Schema(value)
+            }
+        }
+        impl TryFrom<Effect> for ::crux_core::Request<SchemaRequest> {
+            type Error = Effect;
+            fn try_from(value: Effect) -> Result<Self, Self::Error> {
+                if let Effect::Schema(value) = value { Ok(value) } else { Err(value) }
+            }
+        }
+        impl From<::crux_core::Request<UpdateRequest>> for Effect {
+            fn from(value: ::crux_core::Request<UpdateRequest>) -> Self {
+                Self::Update(value)
+            }
+        }
+        impl TryFrom<Effect> for ::crux_core::Request<UpdateRequest> {
+            type Error = Effect;
+            fn try_from(value: Effect) -> Result<Self, Self::Error> {
+                if let Effect::Update(value) = value { Ok(value) } else { Err(value) }
+            }
+        }
+        impl From<::crux_core::Request<ResolveRequest>> for Effect {
+            fn from(value: ::crux_core::Request<ResolveRequest>) -> Self {
+                Self::Resolve(value)
+            }
+        }
+        impl TryFrom<Effect> for ::crux_core::Request<ResolveRequest> {
+            type Error = Effect;
+            fn try_from(value: Effect) -> Result<Self, Self::Error> {
+                if let Effect::Resolve(value) = value { Ok(value) } else { Err(value) }
+            }
+        }
+        impl From<::crux_core::Request<ViewRequest>> for Effect {
+            fn from(value: ::crux_core::Request<ViewRequest>) -> Self {
+                Self::View(value)
+            }
+        }
+        impl TryFrom<Effect> for ::crux_core::Request<ViewRequest> {
+            type Error = Effect;
+            fn try_from(value: Effect) -> Result<Self, Self::Error> {
+                if let Effect::View(value) = value { Ok(value) } else { Err(value) }
+            }
+        }
+        impl From<::crux_core::Request<RenderRequest>> for Effect {
+            fn from(value: ::crux_core::Request<RenderRequest>) -> Self {
+                Self::Render(value)
+            }
+        }
+        impl TryFrom<Effect> for ::crux_core::Request<RenderRequest> {
+            type Error = Effect;
+            fn try_from(value: Effect) -> Result<Self, Self::Error> {
+                if let Effect::Render(value) = value { Ok(value) } else { Err(value) }
+            }
+        }
+        impl Effect {
+            pub fn is_schema(&self) -> bool {
+                if let Effect::Schema(_) = self { true } else { false }
+            }
+            pub fn into_schema(self) -> Option<::crux_core::Request<SchemaRequest>> {
+                if let Effect::Schema(request) = self { Some(request) } else { None }
+            }
+            #[track_caller]
+            pub fn expect_schema(self) -> ::crux_core::Request<SchemaRequest> {
+                if let Effect::Schema(request) = self {
+                    request
+                } else {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("not a {0} effect", "Schema"),
+                        );
+                    }
+                }
+            }
+        }
+        impl Effect {
+            pub fn is_update(&self) -> bool {
+                if let Effect::Update(_) = self { true } else { false }
+            }
+            pub fn into_update(self) -> Option<::crux_core::Request<UpdateRequest>> {
+                if let Effect::Update(request) = self { Some(request) } else { None }
+            }
+            #[track_caller]
+            pub fn expect_update(self) -> ::crux_core::Request<UpdateRequest> {
+                if let Effect::Update(request) = self {
+                    request
+                } else {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("not a {0} effect", "Update"),
+                        );
+                    }
+                }
+            }
+        }
+        impl Effect {
+            pub fn is_resolve(&self) -> bool {
+                if let Effect::Resolve(_) = self { true } else { false }
+            }
+            pub fn into_resolve(self) -> Option<::crux_core::Request<ResolveRequest>> {
+                if let Effect::Resolve(request) = self { Some(request) } else { None }
+            }
+            #[track_caller]
+            pub fn expect_resolve(self) -> ::crux_core::Request<ResolveRequest> {
+                if let Effect::Resolve(request) = self {
+                    request
+                } else {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("not a {0} effect", "Resolve"),
+                        );
+                    }
+                }
+            }
+        }
+        impl Effect {
+            pub fn is_view(&self) -> bool {
+                if let Effect::View(_) = self { true } else { false }
+            }
+            pub fn into_view(self) -> Option<::crux_core::Request<ViewRequest>> {
+                if let Effect::View(request) = self { Some(request) } else { None }
+            }
+            #[track_caller]
+            pub fn expect_view(self) -> ::crux_core::Request<ViewRequest> {
+                if let Effect::View(request) = self {
+                    request
+                } else {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("not a {0} effect", "View"),
+                        );
+                    }
+                }
+            }
+        }
+        impl Effect {
+            pub fn is_render(&self) -> bool {
+                if let Effect::Render(_) = self { true } else { false }
+            }
+            pub fn into_render(self) -> Option<::crux_core::Request<RenderRequest>> {
+                if let Effect::Render(request) = self { Some(request) } else { None }
+            }
+            #[track_caller]
+            pub fn expect_render(self) -> ::crux_core::Request<RenderRequest> {
+                if let Effect::Render(request) = self {
+                    request
+                } else {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("not a {0} effect", "Render"),
+                        );
+                    }
+                }
+            }
+        }
+        pub struct App;
+        #[automatically_derived]
+        impl ::core::default::Default for App {
+            #[inline]
+            fn default() -> App {
+                App {}
+            }
+        }
+        impl crux_core::App for App {
+            type Model = Model;
+            type Event = Event;
+            type ViewModel = ();
+            type Capabilities = ();
+            type Effect = Effect;
+            fn update(
+                &self,
+                event: Self::Event,
+                _model: &mut Self::Model,
+                _caps: &Self::Capabilities,
+            ) -> Command<Effect, Event> {
+                match event {
+                    Event::Schema(_) => get_schema().then_send(Event::GotSchema),
+                    Event::Update(request) => {
+                        call_update(request.data).then_send(Event::GotUpdate)
+                    }
+                    Event::Resolve(request) => {
+                        call_resolve(request).then_send(Event::GotResolve)
+                    }
+                    Event::View(_) => call_view().then_send(Event::GotView),
+                    Event::GotSchema(SchemaResponse(result))
+                    | Event::GotUpdate(UpdateResponse(result))
+                    | Event::GotResolve(ResolveResponse(result))
+                    | Event::GotView(ViewResponse(result)) => render::render(result),
+                }
+            }
+            fn view(&self, _model: &Self::Model) -> Self::ViewModel {}
+        }
+    }
+    pub mod capabilities {
+        pub mod render {
+            use crux_core::{Command, Request, capability::Operation};
+            use crate::Result;
+            pub struct RenderRequest(pub Result<Vec<u8>>);
+            impl Operation for RenderRequest {
+                type Output = ();
+            }
+            pub fn render<Effect, Event>(
+                result: Result<Vec<u8>>,
+            ) -> Command<Effect, Event>
+            where
+                Effect: From<Request<RenderRequest>> + Send + 'static,
+                Event: Send + 'static,
+            {
+                Command::notify_shell(RenderRequest(result)).build()
+            }
+        }
+        pub mod resolve {
+            use crux_core::{
+                Command, Request, capability::Operation, command::RequestBuilder,
+            };
+            use crate::Result;
+            pub struct ResolveRequest {
+                pub effect_id: u32,
+                pub data: Vec<u8>,
+            }
+            pub struct ResolveResponse(pub Result<Vec<u8>>);
+            impl Operation for ResolveRequest {
+                type Output = ResolveResponse;
+            }
+            pub fn call_resolve<Effect, Event>(
+                req: ResolveRequest,
+            ) -> RequestBuilder<Effect, Event, impl Future<Output = ResolveResponse>>
+            where
+                Effect: From<Request<ResolveRequest>> + Send + 'static,
+                Event: Send + 'static,
+            {
+                Command::request_from_shell(req)
+            }
+        }
+        pub mod schema {
+            use crux_core::{
+                Command, Request, capability::Operation, command::RequestBuilder,
+            };
+            use crate::Result;
+            pub struct SchemaRequest;
+            pub struct SchemaResponse(pub Result<Vec<u8>>);
+            impl Operation for SchemaRequest {
+                type Output = SchemaResponse;
+            }
+            pub fn get_schema<Effect, Event>() -> RequestBuilder<
+                Effect,
+                Event,
+                impl Future<Output = SchemaResponse>,
+            >
+            where
+                Effect: From<Request<SchemaRequest>> + Send + 'static,
+                Event: Send + 'static,
+            {
+                Command::request_from_shell(SchemaRequest)
+            }
+        }
+        pub mod update {
+            use crux_core::{
+                Command, Request, capability::Operation, command::RequestBuilder,
+            };
+            use crate::Result;
+            pub struct UpdateRequest {
+                pub data: Vec<u8>,
+            }
+            pub struct UpdateResponse(pub Result<Vec<u8>>);
+            impl Operation for UpdateRequest {
+                type Output = UpdateResponse;
+            }
+            pub fn call_update<Effect, Event>(
+                data: Vec<u8>,
+            ) -> RequestBuilder<Effect, Event, impl Future<Output = UpdateResponse>>
+            where
+                Effect: From<Request<UpdateRequest>> + Send + 'static,
+                Event: Send + 'static,
+            {
+                Command::request_from_shell(UpdateRequest { data })
+            }
+        }
+        pub mod view {
+            use crux_core::{
+                Command, Request, capability::Operation, command::RequestBuilder,
+            };
+            use crate::Result;
+            pub struct ViewRequest;
+            pub struct ViewResponse(pub Result<Vec<u8>>);
+            impl Operation for ViewRequest {
+                type Output = ViewResponse;
+            }
+            pub fn call_view<Effect, Event>() -> RequestBuilder<
+                Effect,
+                Event,
+                impl Future<Output = ViewResponse>,
+            >
+            where
+                Effect: From<Request<ViewRequest>> + Send + 'static,
+                Event: Send + 'static,
+            {
+                Command::request_from_shell(ViewRequest)
+            }
+        }
+    }
+}
+mod error {
+    use thiserror::Error;
+    pub enum Error {
+        #[error("channel closed")]
+        ChannelClosed,
+        #[error(transparent)]
+        Other(#[from] anyhow::Error),
+    }
+    #[allow(unused_qualifications)]
+    #[automatically_derived]
+    impl ::thiserror::__private::Error for Error {
+        fn source(
+            &self,
+        ) -> ::core::option::Option<&(dyn ::thiserror::__private::Error + 'static)> {
+            use ::thiserror::__private::AsDynError as _;
+            #[allow(deprecated)]
+            match self {
+                Error::ChannelClosed { .. } => ::core::option::Option::None,
+                Error::Other { 0: transparent } => {
+                    ::thiserror::__private::Error::source(transparent.as_dyn_error())
+                }
+            }
+        }
+    }
+    #[allow(unused_qualifications)]
+    #[automatically_derived]
+    impl ::core::fmt::Display for Error {
+        fn fmt(&self, __formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            #[allow(unused_variables, deprecated, clippy::used_underscore_binding)]
+            match self {
+                Error::ChannelClosed {} => __formatter.write_str("channel closed"),
+                Error::Other(_0) => ::core::fmt::Display::fmt(_0, __formatter),
+            }
+        }
+    }
+    #[allow(
+        deprecated,
+        unused_qualifications,
+        clippy::elidable_lifetime_names,
+        clippy::needless_lifetimes,
+    )]
+    #[automatically_derived]
+    impl ::core::convert::From<anyhow::Error> for Error {
+        fn from(source: anyhow::Error) -> Self {
+            Error::Other { 0: source }
+        }
+    }
+    #[automatically_derived]
+    impl ::core::fmt::Debug for Error {
+        #[inline]
+        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+            match self {
+                Error::ChannelClosed => {
+                    ::core::fmt::Formatter::write_str(f, "ChannelClosed")
+                }
+                Error::Other(__self_0) => {
+                    ::core::fmt::Formatter::debug_tuple_field1_finish(
+                        f,
+                        "Other",
+                        &__self_0,
+                    )
+                }
+            }
+        }
+    }
+    pub type Result<T> = std::result::Result<T, Error>;
+}
+mod event_loop {
+    use std::string::String;
+    use tokio::sync::mpsc::Sender;
+    use crate::{
+        Error,
+        core::{
+            app::{App, Effect, Event},
+            capabilities::{
+                resolve::ResolveResponse, schema::SchemaResponse, update::UpdateResponse,
+                view::ViewResponse,
+            },
+        },
+        error::Result, shell::host::Host,
+    };
+    pub struct Core {
+        core: crux_core::Core<App>,
+        host: Host,
+    }
+    impl Core {
+        pub fn new(host: Host) -> Self {
+            Self {
+                core: crux_core::Core::new(),
+                host,
+            }
+        }
+        pub fn update(&self, event: Event, tx: &Sender<Result<Vec<u8>>>) {
+            for effect in self.core.process_event(event) {
+                self.process_effect(effect, tx);
+            }
+        }
+        fn process_effect(&self, effect: Effect, tx: &Sender<Result<Vec<u8>>>) {
+            let effects = match effect {
+                Effect::Schema(mut request) => {
+                    let result = self
+                        .host
+                        .schema()
+                        .map(String::into_bytes)
+                        .map_err(Error::Other);
+                    self.core
+                        .resolve(&mut request, SchemaResponse(result))
+                        .expect("should resolve")
+                }
+                Effect::Update(request) => {
+                    let (request, mut handler) = request.split();
+                    let result = self.host.update(request.data).map_err(Error::Other);
+                    self.core
+                        .resolve(&mut handler, UpdateResponse(result))
+                        .expect("should resolve")
+                }
+                Effect::Resolve(request) => {
+                    let (request, mut handler) = request.split();
+                    let result = self
+                        .host
+                        .resolve(request.effect_id, request.data)
+                        .map_err(Error::Other);
+                    self.core
+                        .resolve(&mut handler, ResolveResponse(result))
+                        .expect("should resolve")
+                }
+                Effect::View(mut request) => {
+                    let result = self.host.view().map_err(Error::Other);
+                    self.core
+                        .resolve(&mut request, ViewResponse(result))
+                        .expect("should resolve")
+                }
+                Effect::Render(request) => {
+                    let (request, _) = request.split();
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        tx.send(request.0).await.expect("receiver dropped");
+                    });
+                    ::alloc::vec::Vec::new()
+                }
+            };
+            for effect in effects {
+                self.process_effect(effect, tx);
+            }
+        }
+    }
+}
+mod shell {
+    pub mod host {
+        use std::{env, path::PathBuf, sync::{Arc, Mutex}};
+        use anyhow::{Result, anyhow, bail};
+        use wasmtime::{
+            Engine, Store,
+            component::{Component, Linker, ResourceTable, TypedFunc, bindgen},
+        };
+        use wasmtime_wasi::p2::{
+            IoView, WasiCtx, WasiCtxBuilder, WasiView, add_to_linker_sync,
+        };
+        /// Auto-generated bindings for a pre-instantiated version of a
+        /// component which implements the world `shared`.
+        ///
+        /// This structure is created through [`SharedPre::new`] which
+        /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+        /// has been created through a [`Linker`](wasmtime::component::Linker).
+        ///
+        /// For more information see [`Shared`] as well.
+        pub struct SharedPre<T: 'static> {
+            instance_pre: wasmtime::component::InstancePre<T>,
+            indices: SharedIndices,
+        }
+        impl<T: 'static> Clone for SharedPre<T> {
+            fn clone(&self) -> Self {
+                Self {
+                    instance_pre: self.instance_pre.clone(),
+                    indices: self.indices.clone(),
+                }
+            }
+        }
+        impl<_T: 'static> SharedPre<_T> {
+            /// Creates a new copy of `SharedPre` bindings which can then
+            /// be used to instantiate into a particular store.
+            ///
+            /// This method may fail if the component behind `instance_pre`
+            /// does not have the required exports.
+            pub fn new(
+                instance_pre: wasmtime::component::InstancePre<_T>,
+            ) -> wasmtime::Result<Self> {
+                let indices = SharedIndices::new(&instance_pre)?;
+                Ok(Self { instance_pre, indices })
+            }
+            pub fn engine(&self) -> &wasmtime::Engine {
+                self.instance_pre.engine()
+            }
+            pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+                &self.instance_pre
+            }
+            /// Instantiates a new instance of [`Shared`] within the
+            /// `store` provided.
+            ///
+            /// This function will use `self` as the pre-instantiated
+            /// instance to perform instantiation. Afterwards the preloaded
+            /// indices in `self` are used to lookup all exports on the
+            /// resulting instance.
+            pub fn instantiate(
+                &self,
+                mut store: impl wasmtime::AsContextMut<Data = _T>,
+            ) -> wasmtime::Result<Shared> {
+                let mut store = store.as_context_mut();
+                let instance = self.instance_pre.instantiate(&mut store)?;
+                self.indices.load(&mut store, &instance)
+            }
+        }
+        /// Auto-generated bindings for index of the exports of
+        /// `shared`.
+        ///
+        /// This is an implementation detail of [`SharedPre`] and can
+        /// be constructed if needed as well.
+        ///
+        /// For more information see [`Shared`] as well.
+        pub struct SharedIndices {}
+        #[automatically_derived]
+        impl ::core::clone::Clone for SharedIndices {
+            #[inline]
+            fn clone(&self) -> SharedIndices {
+                SharedIndices {}
+            }
+        }
+        /// Auto-generated bindings for an instance a component which
+        /// implements the world `shared`.
+        ///
+        /// This structure can be created through a number of means
+        /// depending on your requirements and what you have on hand:
+        ///
+        /// * The most convenient way is to use
+        ///   [`Shared::instantiate`] which only needs a
+        ///   [`Store`], [`Component`], and [`Linker`].
+        ///
+        /// * Alternatively you can create a [`SharedPre`] ahead of
+        ///   time with a [`Component`] to front-load string lookups
+        ///   of exports once instead of per-instantiation. This
+        ///   method then uses [`SharedPre::instantiate`] to
+        ///   create a [`Shared`].
+        ///
+        /// * If you've instantiated the instance yourself already
+        ///   then you can use [`Shared::new`].
+        ///
+        /// These methods are all equivalent to one another and move
+        /// around the tradeoff of what work is performed when.
+        ///
+        /// [`Store`]: wasmtime::Store
+        /// [`Component`]: wasmtime::component::Component
+        /// [`Linker`]: wasmtime::component::Linker
+        pub struct Shared {}
+        const _: () = {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::anyhow;
+            impl SharedIndices {
+                /// Creates a new copy of `SharedIndices` bindings which can then
+                /// be used to instantiate into a particular store.
+                ///
+                /// This method may fail if the component does not have the
+                /// required exports.
+                pub fn new<_T>(
+                    _instance_pre: &wasmtime::component::InstancePre<_T>,
+                ) -> wasmtime::Result<Self> {
+                    let _component = _instance_pre.component();
+                    let _instance_type = _instance_pre.instance_type();
+                    Ok(SharedIndices {})
+                }
+                /// Uses the indices stored in `self` to load an instance
+                /// of [`Shared`] from the instance provided.
+                ///
+                /// Note that at this time this method will additionally
+                /// perform type-checks of all exports.
+                pub fn load(
+                    &self,
+                    mut store: impl wasmtime::AsContextMut,
+                    instance: &wasmtime::component::Instance,
+                ) -> wasmtime::Result<Shared> {
+                    let _ = &mut store;
+                    let _instance = instance;
+                    Ok(Shared {})
+                }
+            }
+            impl Shared {
+                /// Convenience wrapper around [`SharedPre::new`] and
+                /// [`SharedPre::instantiate`].
+                pub fn instantiate<_T>(
+                    store: impl wasmtime::AsContextMut<Data = _T>,
+                    component: &wasmtime::component::Component,
+                    linker: &wasmtime::component::Linker<_T>,
+                ) -> wasmtime::Result<Shared> {
+                    let pre = linker.instantiate_pre(component)?;
+                    SharedPre::new(pre)?.instantiate(store)
+                }
+                /// Convenience wrapper around [`SharedIndices::new`] and
+                /// [`SharedIndices::load`].
+                pub fn new(
+                    mut store: impl wasmtime::AsContextMut,
+                    instance: &wasmtime::component::Instance,
+                ) -> wasmtime::Result<Shared> {
+                    let indices = SharedIndices::new(&instance.instance_pre(&store))?;
+                    indices.load(&mut store, instance)
+                }
+                pub fn add_to_linker<T, D>(
+                    linker: &mut wasmtime::component::Linker<T>,
+                    host_getter: fn(&mut T) -> D::Data<'_>,
+                ) -> wasmtime::Result<()>
+                where
+                    D: wasmtime::component::HasData,
+                    for<'a> D::Data<'a>: crux::shared_lib::core::Host,
+                    T: 'static,
+                {
+                    crux::shared_lib::core::add_to_linker::<T, D>(linker, host_getter)?;
+                    Ok(())
+                }
+            }
+        };
+        pub mod crux {
+            pub mod shared_lib {
+                #[allow(clippy::all)]
+                pub mod core {
+                    #[allow(unused_imports)]
+                    use wasmtime::component::__internal::{anyhow, Box};
+                    pub enum Instance {}
+                    pub trait HostInstance {
+                        fn new(&mut self) -> wasmtime::component::Resource<Instance>;
+                        fn update(
+                            &mut self,
+                            self_: wasmtime::component::Resource<Instance>,
+                            data: wasmtime::component::__internal::Vec<u8>,
+                        ) -> Result<
+                            wasmtime::component::__internal::Vec<u8>,
+                            wasmtime::component::__internal::String,
+                        >;
+                        fn resolve(
+                            &mut self,
+                            self_: wasmtime::component::Resource<Instance>,
+                            effect_id: u32,
+                            data: wasmtime::component::__internal::Vec<u8>,
+                        ) -> Result<
+                            wasmtime::component::__internal::Vec<u8>,
+                            wasmtime::component::__internal::String,
+                        >;
+                        fn view(
+                            &mut self,
+                            self_: wasmtime::component::Resource<Instance>,
+                        ) -> Result<
+                            wasmtime::component::__internal::Vec<u8>,
+                            wasmtime::component::__internal::String,
+                        >;
+                        fn schema(
+                            &mut self,
+                            self_: wasmtime::component::Resource<Instance>,
+                        ) -> wasmtime::component::__internal::String;
+                        fn drop(
+                            &mut self,
+                            rep: wasmtime::component::Resource<Instance>,
+                        ) -> wasmtime::Result<()>;
+                    }
+                    impl<_T: HostInstance + ?Sized> HostInstance for &mut _T {
+                        fn new(&mut self) -> wasmtime::component::Resource<Instance> {
+                            HostInstance::new(*self)
+                        }
+                        fn update(
+                            &mut self,
+                            self_: wasmtime::component::Resource<Instance>,
+                            data: wasmtime::component::__internal::Vec<u8>,
+                        ) -> Result<
+                            wasmtime::component::__internal::Vec<u8>,
+                            wasmtime::component::__internal::String,
+                        > {
+                            HostInstance::update(*self, self_, data)
+                        }
+                        fn resolve(
+                            &mut self,
+                            self_: wasmtime::component::Resource<Instance>,
+                            effect_id: u32,
+                            data: wasmtime::component::__internal::Vec<u8>,
+                        ) -> Result<
+                            wasmtime::component::__internal::Vec<u8>,
+                            wasmtime::component::__internal::String,
+                        > {
+                            HostInstance::resolve(*self, self_, effect_id, data)
+                        }
+                        fn view(
+                            &mut self,
+                            self_: wasmtime::component::Resource<Instance>,
+                        ) -> Result<
+                            wasmtime::component::__internal::Vec<u8>,
+                            wasmtime::component::__internal::String,
+                        > {
+                            HostInstance::view(*self, self_)
+                        }
+                        fn schema(
+                            &mut self,
+                            self_: wasmtime::component::Resource<Instance>,
+                        ) -> wasmtime::component::__internal::String {
+                            HostInstance::schema(*self, self_)
+                        }
+                        fn drop(
+                            &mut self,
+                            rep: wasmtime::component::Resource<Instance>,
+                        ) -> wasmtime::Result<()> {
+                            HostInstance::drop(*self, rep)
+                        }
+                    }
+                    pub trait Host: HostInstance {}
+                    impl<_T: Host + ?Sized> Host for &mut _T {}
+                    pub fn add_to_linker<T, D>(
+                        linker: &mut wasmtime::component::Linker<T>,
+                        host_getter: fn(&mut T) -> D::Data<'_>,
+                    ) -> wasmtime::Result<()>
+                    where
+                        D: wasmtime::component::HasData,
+                        for<'a> D::Data<'a>: Host,
+                        T: 'static,
+                    {
+                        let mut inst = linker.instance("crux:shared-lib/core")?;
+                        inst.resource(
+                            "instance",
+                            wasmtime::component::ResourceType::host::<Instance>(),
+                            move |mut store, rep| -> wasmtime::Result<()> {
+                                HostInstance::drop(
+                                    &mut host_getter(store.data_mut()),
+                                    wasmtime::component::Resource::new_own(rep),
+                                )
+                            },
+                        )?;
+                        inst.func_wrap(
+                            "[constructor]instance",
+                            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                                let host = &mut host_getter(caller.data_mut());
+                                let r = HostInstance::new(host);
+                                Ok((r,))
+                            },
+                        )?;
+                        inst.func_wrap(
+                            "[method]instance.update",
+                            move |
+                                mut caller: wasmtime::StoreContextMut<'_, T>,
+                                (
+                                    arg0,
+                                    arg1,
+                                ): (
+                                    wasmtime::component::Resource<Instance>,
+                                    wasmtime::component::__internal::Vec<u8>,
+                                )|
+                            {
+                                let host = &mut host_getter(caller.data_mut());
+                                let r = HostInstance::update(host, arg0, arg1);
+                                Ok((r,))
+                            },
+                        )?;
+                        inst.func_wrap(
+                            "[method]instance.resolve",
+                            move |
+                                mut caller: wasmtime::StoreContextMut<'_, T>,
+                                (
+                                    arg0,
+                                    arg1,
+                                    arg2,
+                                ): (
+                                    wasmtime::component::Resource<Instance>,
+                                    u32,
+                                    wasmtime::component::__internal::Vec<u8>,
+                                )|
+                            {
+                                let host = &mut host_getter(caller.data_mut());
+                                let r = HostInstance::resolve(host, arg0, arg1, arg2);
+                                Ok((r,))
+                            },
+                        )?;
+                        inst.func_wrap(
+                            "[method]instance.view",
+                            move |
+                                mut caller: wasmtime::StoreContextMut<'_, T>,
+                                (arg0,): (wasmtime::component::Resource<Instance>,)|
+                            {
+                                let host = &mut host_getter(caller.data_mut());
+                                let r = HostInstance::view(host, arg0);
+                                Ok((r,))
+                            },
+                        )?;
+                        inst.func_wrap(
+                            "[method]instance.schema",
+                            move |
+                                mut caller: wasmtime::StoreContextMut<'_, T>,
+                                (arg0,): (wasmtime::component::Resource<Instance>,)|
+                            {
+                                let host = &mut host_getter(caller.data_mut());
+                                let r = HostInstance::schema(host, arg0);
+                                Ok((r,))
+                            },
+                        )?;
+                        Ok(())
+                    }
+                }
+            }
+        }
+        const _: &str = "package crux:shared-lib;\n\nworld shared {\n    import core;\n}\n";
+        const _: &str = "package crux:shared-lib;\n\ninterface core {\n    resource instance {\n        constructor();\n        update: func(data: list<u8>) -> result<list<u8>, string>;\n        resolve: func(effect-id: u32, data: list<u8>) -> result<list<u8>, string>;\n        view: func() -> result<list<u8>, string>;\n        schema: func() -> string;\n    }\n}\n";
+        pub struct ComponentRunStates {
+            pub wasi_ctx: WasiCtx,
+            pub resource_table: ResourceTable,
+        }
+        impl IoView for ComponentRunStates {
+            fn table(&mut self) -> &mut ResourceTable {
+                &mut self.resource_table
+            }
+        }
+        impl WasiView for ComponentRunStates {
+            fn ctx(&mut self) -> &mut WasiCtx {
+                &mut self.wasi_ctx
+            }
+        }
+        type Bytes = Vec<u8>;
+        #[allow(clippy::type_complexity)]
+        pub struct Host {
+            store: Arc<Mutex<Option<Store<ComponentRunStates>>>>,
+            schema: Option<TypedFunc<(), (String,)>>,
+            update: Option<TypedFunc<(Bytes,), (Result<Bytes, String>,)>>,
+            resolve: Option<TypedFunc<(u32, Bytes), (Result<Bytes, String>,)>>,
+            view: Option<TypedFunc<(), (Result<Bytes, String>,)>>,
+        }
+        #[automatically_derived]
+        #[allow(clippy::type_complexity)]
+        impl ::core::default::Default for Host {
+            #[inline]
+            fn default() -> Host {
+                Host {
+                    store: ::core::default::Default::default(),
+                    schema: ::core::default::Default::default(),
+                    update: ::core::default::Default::default(),
+                    resolve: ::core::default::Default::default(),
+                    view: ::core::default::Default::default(),
+                }
+            }
+        }
+        impl Host {
+            pub fn load(&mut self) -> Result<()> {
+                let engine = Engine::default();
+                let mut linker = Linker::new(&engine);
+                add_to_linker_sync(&mut linker)?;
+                let state = ComponentRunStates {
+                    wasi_ctx: WasiCtxBuilder::new()
+                        .inherit_stdio()
+                        .inherit_args()
+                        .build(),
+                    resource_table: ResourceTable::new(),
+                };
+                let mut store = Store::new(&engine, state);
+                let file = PathBuf::from(env::var("CRUX_COMPONENT")?);
+                let component = Component::from_file(&engine, file)?;
+                let instance = linker.instantiate(&mut store, &component)?;
+                if let Some(func) = instance.get_func(&mut store, "schema") {
+                    self.schema = Some(func.typed::<(), (String,)>(&store)?);
+                } else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("schema function not found"),
+                        );
+                        error
+                    });
+                }
+                if let Some(func) = instance.get_func(&mut store, "update") {
+                    self.update = Some(
+                        func.typed::<(Bytes,), (Result<Bytes, String>,)>(&store)?,
+                    );
+                } else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("update function not found"),
+                        );
+                        error
+                    });
+                }
+                if let Some(func) = instance.get_func(&mut store, "resolve") {
+                    self.resolve = Some(
+                        func.typed::<(u32, Bytes), (Result<Bytes, String>,)>(&store)?,
+                    );
+                } else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("resolve function not found"),
+                        );
+                        error
+                    });
+                }
+                if let Some(func) = instance.get_func(&mut store, "view") {
+                    self.view = Some(
+                        func.typed::<(), (Result<Bytes, String>,)>(&store)?,
+                    );
+                } else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("view function not found"),
+                        );
+                        error
+                    });
+                }
+                self.store = Arc::new(Mutex::new(Some(store)));
+                Ok(())
+            }
+            pub fn schema(&self) -> Result<String> {
+                let Some(schema) = self.schema else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("no schema function"),
+                        );
+                        error
+                    });
+                };
+                let mut store = self.store.lock().expect("failed to lock store");
+                let Some(mut store) = store.as_mut() else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("no store"),
+                        );
+                        error
+                    });
+                };
+                let (data,) = schema.call(&mut store, ())?;
+                schema.post_return(&mut store)?;
+                Ok(data)
+            }
+            pub fn update(&self, data: Vec<u8>) -> Result<Vec<u8>> {
+                let Some(update) = self.update else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("no update function"),
+                        );
+                        error
+                    });
+                };
+                let mut store = self.store.lock().expect("failed to lock store");
+                let Some(mut store) = store.as_mut() else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("no store"),
+                        );
+                        error
+                    });
+                };
+                let (data,) = update.call(&mut store, (data,))?;
+                update.post_return(&mut store)?;
+                data.map_err(|e| ::anyhow::__private::must_use({
+                    let error = ::anyhow::__private::format_err(
+                        format_args!("bridge error: {0}", e),
+                    );
+                    error
+                }))
+            }
+            pub fn resolve(&self, effect_id: u32, data: Vec<u8>) -> Result<Vec<u8>> {
+                let Some(resolve) = self.resolve else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("no update function"),
+                        );
+                        error
+                    });
+                };
+                let mut store = self.store.lock().expect("failed to lock store");
+                let Some(mut store) = store.as_mut() else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("no store"),
+                        );
+                        error
+                    });
+                };
+                let (data,) = resolve.call(&mut store, (effect_id, data))?;
+                resolve.post_return(&mut store)?;
+                data.map_err(|e| ::anyhow::__private::must_use({
+                    let error = ::anyhow::__private::format_err(
+                        format_args!("bridge error: {0}", e),
+                    );
+                    error
+                }))
+            }
+            pub fn view(&self) -> Result<Vec<u8>> {
+                let Some(view) = &self.view else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("no view function"),
+                        );
+                        error
+                    });
+                };
+                let mut store = self.store.lock().expect("failed to lock store");
+                let Some(mut store) = store.as_mut() else {
+                    return ::anyhow::__private::Err({
+                        let error = ::anyhow::__private::format_err(
+                            format_args!("no store"),
+                        );
+                        error
+                    });
+                };
+                let (data,) = view.call(&mut store, ())?;
+                view.post_return(&mut store)?;
+                data.map_err(|e| ::anyhow::__private::must_use({
+                    let error = ::anyhow::__private::format_err(
+                        format_args!("bridge error: {0}", e),
+                    );
+                    error
+                }))
+            }
+        }
+    }
+    pub mod mcp {
+        pub mod handler {
+            use std::result::Result;
+            use anyhow::anyhow;
+            use async_trait::async_trait;
+            use rust_mcp_sdk::schema::{
+                CallToolRequest, CallToolResult, ListToolsRequest, ListToolsResult,
+                RpcError, schema_utils::CallToolError,
+            };
+            use rust_mcp_sdk::{McpServer, mcp_server::ServerHandler};
+            use tokio::sync::mpsc;
+            use crate::Error;
+            use crate::event_loop::Core;
+            use crate::shell::mcp::MyTools;
+            pub struct MyServerHandler {
+                core: Core,
+            }
+            impl MyServerHandler {
+                pub fn new(core: Core) -> Self {
+                    Self { core }
+                }
+            }
+            #[allow(unused)]
+            impl ServerHandler for MyServerHandler {
+                #[allow(
+                    elided_named_lifetimes,
+                    clippy::async_yields_async,
+                    clippy::diverging_sub_expression,
+                    clippy::let_unit_value,
+                    clippy::needless_arbitrary_self_type,
+                    clippy::no_effect_underscore_binding,
+                    clippy::shadow_same,
+                    clippy::type_complexity,
+                    clippy::type_repetition_in_bounds,
+                    clippy::used_underscore_binding
+                )]
+                fn handle_list_tools_request<'life0, 'life1, 'async_trait>(
+                    &'life0 self,
+                    request: ListToolsRequest,
+                    runtime: &'life1 dyn McpServer,
+                ) -> ::core::pin::Pin<
+                    Box<
+                        dyn ::core::future::Future<
+                            Output = Result<ListToolsResult, RpcError>,
+                        > + ::core::marker::Send + 'async_trait,
+                    >,
+                >
+                where
+                    'life0: 'async_trait,
+                    'life1: 'async_trait,
+                    Self: 'async_trait,
+                {
+                    Box::pin(async move {
+                        if let ::core::option::Option::Some(__ret) = ::core::option::Option::None::<
+                            Result<ListToolsResult, RpcError>,
+                        > {
+                            #[allow(unreachable_code)] return __ret;
+                        }
+                        let __self = self;
+                        let request = request;
+                        let __ret: Result<ListToolsResult, RpcError> = {
+                            Ok(ListToolsResult {
+                                meta: None,
+                                next_cursor: None,
+                                tools: MyTools::tools(),
+                            })
+                        };
+                        #[allow(unreachable_code)] __ret
+                    })
+                }
+                /// Handles incoming CallToolRequest and processes it using the appropriate tool.
+                #[allow(
+                    elided_named_lifetimes,
+                    clippy::async_yields_async,
+                    clippy::diverging_sub_expression,
+                    clippy::let_unit_value,
+                    clippy::needless_arbitrary_self_type,
+                    clippy::no_effect_underscore_binding,
+                    clippy::shadow_same,
+                    clippy::type_complexity,
+                    clippy::type_repetition_in_bounds,
+                    clippy::used_underscore_binding
+                )]
+                fn handle_call_tool_request<'life0, 'life1, 'async_trait>(
+                    &'life0 self,
+                    request: CallToolRequest,
+                    _runtime: &'life1 dyn McpServer,
+                ) -> ::core::pin::Pin<
+                    Box<
+                        dyn ::core::future::Future<
+                            Output = Result<CallToolResult, CallToolError>,
+                        > + ::core::marker::Send + 'async_trait,
+                    >,
+                >
+                where
+                    'life0: 'async_trait,
+                    'life1: 'async_trait,
+                    Self: 'async_trait,
+                {
+                    Box::pin(async move {
+                        if let ::core::option::Option::Some(__ret) = ::core::option::Option::None::<
+                            Result<CallToolResult, CallToolError>,
+                        > {
+                            #[allow(unreachable_code)] return __ret;
+                        }
+                        let __self = self;
+                        let request = request;
+                        let __ret: Result<CallToolResult, CallToolError> = {
+                            let params = MyTools::try_from(request.params)?;
+                            let (tx, mut rx) = mpsc::channel(1);
+                            __self.core.update(params.into(), &tx);
+                            match rx.recv().await {
+                                Some(result) => {
+                                    match result {
+                                        Ok(data) => {
+                                            let text = String::from_utf8(data)
+                                                .map_err(CallToolError::new)?;
+                                            Ok(
+                                                CallToolResult::text_content(
+                                                    <[_]>::into_vec(::alloc::boxed::box_new([text.into()])),
+                                                ),
+                                            )
+                                        }
+                                        Err(e) => {
+                                            Err(
+                                                CallToolError::new(
+                                                    Error::Other(
+                                                        ::anyhow::__private::must_use({
+                                                            let error = ::anyhow::__private::format_err(
+                                                                format_args!("{0}", e),
+                                                            );
+                                                            error
+                                                        }),
+                                                    ),
+                                                ),
+                                            )
+                                        }
+                                    }
+                                }
+                                None => Err(CallToolError::new(Error::ChannelClosed)),
+                            }
+                        };
+                        #[allow(unreachable_code)] __ret
+                    })
+                }
+            }
+        }
+        pub mod resolve {
+            use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
+            use serde::{Deserialize, Serialize};
+            use crate::core::capabilities::resolve::ResolveRequest;
+            impl Resolve {
+                /// Returns the name of the tool as a string.
+                pub fn tool_name() -> String {
+                    "resolve".to_string()
+                }
+                /// Constructs and returns a `rust_mcp_schema::Tool` instance.
+                ///
+                /// The tool includes the name, description, input schema, meta, and title derived from
+                /// the struct's attributes.
+                pub fn tool() -> rust_mcp_sdk::schema::Tool {
+                    let json_schema = &Resolve::json_schema();
+                    let required: Vec<_> = match json_schema
+                        .get("required")
+                        .and_then(|r| r.as_array())
+                    {
+                        Some(arr) => {
+                            arr.iter()
+                                .filter_map(|item| item.as_str().map(String::from))
+                                .collect()
+                        }
+                        None => Vec::new(),
+                    };
+                    let properties: Option<
+                        std::collections::HashMap<
+                            String,
+                            serde_json::Map<String, serde_json::Value>,
+                        >,
+                    > = json_schema
+                        .get("properties")
+                        .and_then(|v| v.as_object())
+                        .map(|properties| {
+                            properties
+                                .iter()
+                                .filter_map(|(key, value)| {
+                                    serde_json::to_value(value)
+                                        .ok()
+                                        .and_then(|v| {
+                                            if let serde_json::Value::Object(obj) = v {
+                                                Some(obj)
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .map(|obj| (key.to_string(), obj))
+                                })
+                                .collect()
+                        });
+                    rust_mcp_sdk::schema::Tool {
+                        name: "resolve".to_string(),
+                        description: Some(
+                            "Calls the resolve function in a Crux app".to_string(),
+                        ),
+                        output_schema: None,
+                        title: None,
+                        meta: None,
+                        annotations: Some(rust_mcp_sdk::schema::ToolAnnotations {
+                            destructive_hint: Some(false),
+                            idempotent_hint: Some(false),
+                            open_world_hint: Some(false),
+                            read_only_hint: Some(false),
+                            title: None,
+                        }),
+                        input_schema: rust_mcp_sdk::schema::ToolInputSchema::new(
+                            required,
+                            properties,
+                        ),
+                    }
+                }
+            }
+            pub struct Resolve {
+                pub effect_id: u32,
+                pub data: String,
+            }
+            #[automatically_derived]
+            impl ::core::fmt::Debug for Resolve {
+                #[inline]
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                    ::core::fmt::Formatter::debug_struct_field2_finish(
+                        f,
+                        "Resolve",
+                        "effect_id",
+                        &self.effect_id,
+                        "data",
+                        &&self.data,
+                    )
+                }
+            }
+            #[doc(hidden)]
+            #[allow(
+                non_upper_case_globals,
+                unused_attributes,
+                unused_qualifications,
+                clippy::absolute_paths,
+            )]
+            const _: () = {
+                #[allow(unused_extern_crates, clippy::useless_attribute)]
+                extern crate serde as _serde;
+                #[automatically_derived]
+                impl<'de> _serde::Deserialize<'de> for Resolve {
+                    fn deserialize<__D>(
+                        __deserializer: __D,
+                    ) -> _serde::__private::Result<Self, __D::Error>
+                    where
+                        __D: _serde::Deserializer<'de>,
+                    {
+                        #[allow(non_camel_case_types)]
+                        #[doc(hidden)]
+                        enum __Field {
+                            __field0,
+                            __field1,
+                            __ignore,
+                        }
+                        #[doc(hidden)]
+                        struct __FieldVisitor;
+                        #[automatically_derived]
+                        impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                            type Value = __Field;
+                            fn expecting(
+                                &self,
+                                __formatter: &mut _serde::__private::Formatter,
+                            ) -> _serde::__private::fmt::Result {
+                                _serde::__private::Formatter::write_str(
+                                    __formatter,
+                                    "field identifier",
+                                )
+                            }
+                            fn visit_u64<__E>(
+                                self,
+                                __value: u64,
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    0u64 => _serde::__private::Ok(__Field::__field0),
+                                    1u64 => _serde::__private::Ok(__Field::__field1),
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                            fn visit_str<__E>(
+                                self,
+                                __value: &str,
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    "effect_id" => _serde::__private::Ok(__Field::__field0),
+                                    "data" => _serde::__private::Ok(__Field::__field1),
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                            fn visit_bytes<__E>(
+                                self,
+                                __value: &[u8],
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    b"effect_id" => _serde::__private::Ok(__Field::__field0),
+                                    b"data" => _serde::__private::Ok(__Field::__field1),
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                        }
+                        #[automatically_derived]
+                        impl<'de> _serde::Deserialize<'de> for __Field {
+                            #[inline]
+                            fn deserialize<__D>(
+                                __deserializer: __D,
+                            ) -> _serde::__private::Result<Self, __D::Error>
+                            where
+                                __D: _serde::Deserializer<'de>,
+                            {
+                                _serde::Deserializer::deserialize_identifier(
+                                    __deserializer,
+                                    __FieldVisitor,
+                                )
+                            }
+                        }
+                        #[doc(hidden)]
+                        struct __Visitor<'de> {
+                            marker: _serde::__private::PhantomData<Resolve>,
+                            lifetime: _serde::__private::PhantomData<&'de ()>,
+                        }
+                        #[automatically_derived]
+                        impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                            type Value = Resolve;
+                            fn expecting(
+                                &self,
+                                __formatter: &mut _serde::__private::Formatter,
+                            ) -> _serde::__private::fmt::Result {
+                                _serde::__private::Formatter::write_str(
+                                    __formatter,
+                                    "struct Resolve",
+                                )
+                            }
+                            #[inline]
+                            fn visit_seq<__A>(
+                                self,
+                                mut __seq: __A,
+                            ) -> _serde::__private::Result<Self::Value, __A::Error>
+                            where
+                                __A: _serde::de::SeqAccess<'de>,
+                            {
+                                let __field0 = match _serde::de::SeqAccess::next_element::<
+                                    u32,
+                                >(&mut __seq)? {
+                                    _serde::__private::Some(__value) => __value,
+                                    _serde::__private::None => {
+                                        return _serde::__private::Err(
+                                            _serde::de::Error::invalid_length(
+                                                0usize,
+                                                &"struct Resolve with 2 elements",
+                                            ),
+                                        );
+                                    }
+                                };
+                                let __field1 = match _serde::de::SeqAccess::next_element::<
+                                    String,
+                                >(&mut __seq)? {
+                                    _serde::__private::Some(__value) => __value,
+                                    _serde::__private::None => {
+                                        return _serde::__private::Err(
+                                            _serde::de::Error::invalid_length(
+                                                1usize,
+                                                &"struct Resolve with 2 elements",
+                                            ),
+                                        );
+                                    }
+                                };
+                                _serde::__private::Ok(Resolve {
+                                    effect_id: __field0,
+                                    data: __field1,
+                                })
+                            }
+                            #[inline]
+                            fn visit_map<__A>(
+                                self,
+                                mut __map: __A,
+                            ) -> _serde::__private::Result<Self::Value, __A::Error>
+                            where
+                                __A: _serde::de::MapAccess<'de>,
+                            {
+                                let mut __field0: _serde::__private::Option<u32> = _serde::__private::None;
+                                let mut __field1: _serde::__private::Option<String> = _serde::__private::None;
+                                while let _serde::__private::Some(__key) = _serde::de::MapAccess::next_key::<
+                                    __Field,
+                                >(&mut __map)? {
+                                    match __key {
+                                        __Field::__field0 => {
+                                            if _serde::__private::Option::is_some(&__field0) {
+                                                return _serde::__private::Err(
+                                                    <__A::Error as _serde::de::Error>::duplicate_field(
+                                                        "effect_id",
+                                                    ),
+                                                );
+                                            }
+                                            __field0 = _serde::__private::Some(
+                                                _serde::de::MapAccess::next_value::<u32>(&mut __map)?,
+                                            );
+                                        }
+                                        __Field::__field1 => {
+                                            if _serde::__private::Option::is_some(&__field1) {
+                                                return _serde::__private::Err(
+                                                    <__A::Error as _serde::de::Error>::duplicate_field("data"),
+                                                );
+                                            }
+                                            __field1 = _serde::__private::Some(
+                                                _serde::de::MapAccess::next_value::<String>(&mut __map)?,
+                                            );
+                                        }
+                                        _ => {
+                                            let _ = _serde::de::MapAccess::next_value::<
+                                                _serde::de::IgnoredAny,
+                                            >(&mut __map)?;
+                                        }
+                                    }
+                                }
+                                let __field0 = match __field0 {
+                                    _serde::__private::Some(__field0) => __field0,
+                                    _serde::__private::None => {
+                                        _serde::__private::de::missing_field("effect_id")?
+                                    }
+                                };
+                                let __field1 = match __field1 {
+                                    _serde::__private::Some(__field1) => __field1,
+                                    _serde::__private::None => {
+                                        _serde::__private::de::missing_field("data")?
+                                    }
+                                };
+                                _serde::__private::Ok(Resolve {
+                                    effect_id: __field0,
+                                    data: __field1,
+                                })
+                            }
+                        }
+                        #[doc(hidden)]
+                        const FIELDS: &'static [&'static str] = &["effect_id", "data"];
+                        _serde::Deserializer::deserialize_struct(
+                            __deserializer,
+                            "Resolve",
+                            FIELDS,
+                            __Visitor {
+                                marker: _serde::__private::PhantomData::<Resolve>,
+                                lifetime: _serde::__private::PhantomData,
+                            },
+                        )
+                    }
+                }
+            };
+            #[doc(hidden)]
+            #[allow(
+                non_upper_case_globals,
+                unused_attributes,
+                unused_qualifications,
+                clippy::absolute_paths,
+            )]
+            const _: () = {
+                #[allow(unused_extern_crates, clippy::useless_attribute)]
+                extern crate serde as _serde;
+                #[automatically_derived]
+                impl _serde::Serialize for Resolve {
+                    fn serialize<__S>(
+                        &self,
+                        __serializer: __S,
+                    ) -> _serde::__private::Result<__S::Ok, __S::Error>
+                    where
+                        __S: _serde::Serializer,
+                    {
+                        let mut __serde_state = _serde::Serializer::serialize_struct(
+                            __serializer,
+                            "Resolve",
+                            false as usize + 1 + 1,
+                        )?;
+                        _serde::ser::SerializeStruct::serialize_field(
+                            &mut __serde_state,
+                            "effect_id",
+                            &self.effect_id,
+                        )?;
+                        _serde::ser::SerializeStruct::serialize_field(
+                            &mut __serde_state,
+                            "data",
+                            &self.data,
+                        )?;
+                        _serde::ser::SerializeStruct::end(__serde_state)
+                    }
+                }
+            };
+            impl Resolve {
+                pub fn json_schema() -> serde_json::Map<String, serde_json::Value> {
+                    let mut schema = serde_json::Map::new();
+                    let mut properties = serde_json::Map::new();
+                    let mut required = Vec::new();
+                    properties
+                        .insert(
+                            "effect_id".to_string(),
+                            serde_json::Value::Object({
+                                let mut map = serde_json::Map::new();
+                                map.insert(
+                                    "type".to_string(),
+                                    serde_json::Value::String("number".to_string()),
+                                );
+                                map
+                            }),
+                        );
+                    properties
+                        .insert(
+                            "data".to_string(),
+                            serde_json::Value::Object({
+                                let mut map = serde_json::Map::new();
+                                map.insert(
+                                    "type".to_string(),
+                                    serde_json::Value::String("string".to_string()),
+                                );
+                                map
+                            }),
+                        );
+                    required.push("effect_id".to_string());
+                    required.push("data".to_string());
+                    schema
+                        .insert(
+                            "type".to_string(),
+                            serde_json::Value::String("object".to_string()),
+                        );
+                    schema
+                        .insert(
+                            "properties".to_string(),
+                            serde_json::Value::Object(properties),
+                        );
+                    if !required.is_empty() {
+                        schema
+                            .insert(
+                                "required".to_string(),
+                                serde_json::Value::Array(
+                                    required
+                                        .into_iter()
+                                        .map(serde_json::Value::String)
+                                        .collect(),
+                                ),
+                            );
+                    }
+                    schema
+                }
+            }
+            impl From<Resolve> for ResolveRequest {
+                fn from(resolve: Resolve) -> Self {
+                    ResolveRequest {
+                        effect_id: resolve.effect_id,
+                        data: resolve.data.into_bytes(),
+                    }
+                }
+            }
+        }
+        pub mod schema {
+            use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
+            use serde::{Deserialize, Serialize};
+            use crate::core::capabilities::schema::SchemaRequest;
+            impl Schema {
+                /// Returns the name of the tool as a string.
+                pub fn tool_name() -> String {
+                    "schema".to_string()
+                }
+                /// Constructs and returns a `rust_mcp_schema::Tool` instance.
+                ///
+                /// The tool includes the name, description, input schema, meta, and title derived from
+                /// the struct's attributes.
+                pub fn tool() -> rust_mcp_sdk::schema::Tool {
+                    let json_schema = &Schema::json_schema();
+                    let required: Vec<_> = match json_schema
+                        .get("required")
+                        .and_then(|r| r.as_array())
+                    {
+                        Some(arr) => {
+                            arr.iter()
+                                .filter_map(|item| item.as_str().map(String::from))
+                                .collect()
+                        }
+                        None => Vec::new(),
+                    };
+                    let properties: Option<
+                        std::collections::HashMap<
+                            String,
+                            serde_json::Map<String, serde_json::Value>,
+                        >,
+                    > = json_schema
+                        .get("properties")
+                        .and_then(|v| v.as_object())
+                        .map(|properties| {
+                            properties
+                                .iter()
+                                .filter_map(|(key, value)| {
+                                    serde_json::to_value(value)
+                                        .ok()
+                                        .and_then(|v| {
+                                            if let serde_json::Value::Object(obj) = v {
+                                                Some(obj)
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .map(|obj| (key.to_string(), obj))
+                                })
+                                .collect()
+                        });
+                    rust_mcp_sdk::schema::Tool {
+                        name: "schema".to_string(),
+                        description: Some("Gets the schema of a Crux app".to_string()),
+                        output_schema: None,
+                        title: None,
+                        meta: None,
+                        annotations: Some(rust_mcp_sdk::schema::ToolAnnotations {
+                            destructive_hint: Some(false),
+                            idempotent_hint: Some(false),
+                            open_world_hint: Some(false),
+                            read_only_hint: Some(false),
+                            title: None,
+                        }),
+                        input_schema: rust_mcp_sdk::schema::ToolInputSchema::new(
+                            required,
+                            properties,
+                        ),
+                    }
+                }
+            }
+            pub struct Schema {}
+            #[automatically_derived]
+            impl ::core::fmt::Debug for Schema {
+                #[inline]
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                    ::core::fmt::Formatter::write_str(f, "Schema")
+                }
+            }
+            #[doc(hidden)]
+            #[allow(
+                non_upper_case_globals,
+                unused_attributes,
+                unused_qualifications,
+                clippy::absolute_paths,
+            )]
+            const _: () = {
+                #[allow(unused_extern_crates, clippy::useless_attribute)]
+                extern crate serde as _serde;
+                #[automatically_derived]
+                impl<'de> _serde::Deserialize<'de> for Schema {
+                    fn deserialize<__D>(
+                        __deserializer: __D,
+                    ) -> _serde::__private::Result<Self, __D::Error>
+                    where
+                        __D: _serde::Deserializer<'de>,
+                    {
+                        #[allow(non_camel_case_types)]
+                        #[doc(hidden)]
+                        enum __Field {
+                            __ignore,
+                        }
+                        #[doc(hidden)]
+                        struct __FieldVisitor;
+                        #[automatically_derived]
+                        impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                            type Value = __Field;
+                            fn expecting(
+                                &self,
+                                __formatter: &mut _serde::__private::Formatter,
+                            ) -> _serde::__private::fmt::Result {
+                                _serde::__private::Formatter::write_str(
+                                    __formatter,
+                                    "field identifier",
+                                )
+                            }
+                            fn visit_u64<__E>(
+                                self,
+                                __value: u64,
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                            fn visit_str<__E>(
+                                self,
+                                __value: &str,
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                            fn visit_bytes<__E>(
+                                self,
+                                __value: &[u8],
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                        }
+                        #[automatically_derived]
+                        impl<'de> _serde::Deserialize<'de> for __Field {
+                            #[inline]
+                            fn deserialize<__D>(
+                                __deserializer: __D,
+                            ) -> _serde::__private::Result<Self, __D::Error>
+                            where
+                                __D: _serde::Deserializer<'de>,
+                            {
+                                _serde::Deserializer::deserialize_identifier(
+                                    __deserializer,
+                                    __FieldVisitor,
+                                )
+                            }
+                        }
+                        #[doc(hidden)]
+                        struct __Visitor<'de> {
+                            marker: _serde::__private::PhantomData<Schema>,
+                            lifetime: _serde::__private::PhantomData<&'de ()>,
+                        }
+                        #[automatically_derived]
+                        impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                            type Value = Schema;
+                            fn expecting(
+                                &self,
+                                __formatter: &mut _serde::__private::Formatter,
+                            ) -> _serde::__private::fmt::Result {
+                                _serde::__private::Formatter::write_str(
+                                    __formatter,
+                                    "struct Schema",
+                                )
+                            }
+                            #[inline]
+                            fn visit_seq<__A>(
+                                self,
+                                _: __A,
+                            ) -> _serde::__private::Result<Self::Value, __A::Error>
+                            where
+                                __A: _serde::de::SeqAccess<'de>,
+                            {
+                                _serde::__private::Ok(Schema {})
+                            }
+                            #[inline]
+                            fn visit_map<__A>(
+                                self,
+                                mut __map: __A,
+                            ) -> _serde::__private::Result<Self::Value, __A::Error>
+                            where
+                                __A: _serde::de::MapAccess<'de>,
+                            {
+                                while let _serde::__private::Some(__key) = _serde::de::MapAccess::next_key::<
+                                    __Field,
+                                >(&mut __map)? {
+                                    match __key {
+                                        _ => {
+                                            let _ = _serde::de::MapAccess::next_value::<
+                                                _serde::de::IgnoredAny,
+                                            >(&mut __map)?;
+                                        }
+                                    }
+                                }
+                                _serde::__private::Ok(Schema {})
+                            }
+                        }
+                        #[doc(hidden)]
+                        const FIELDS: &'static [&'static str] = &[];
+                        _serde::Deserializer::deserialize_struct(
+                            __deserializer,
+                            "Schema",
+                            FIELDS,
+                            __Visitor {
+                                marker: _serde::__private::PhantomData::<Schema>,
+                                lifetime: _serde::__private::PhantomData,
+                            },
+                        )
+                    }
+                }
+            };
+            #[doc(hidden)]
+            #[allow(
+                non_upper_case_globals,
+                unused_attributes,
+                unused_qualifications,
+                clippy::absolute_paths,
+            )]
+            const _: () = {
+                #[allow(unused_extern_crates, clippy::useless_attribute)]
+                extern crate serde as _serde;
+                #[automatically_derived]
+                impl _serde::Serialize for Schema {
+                    fn serialize<__S>(
+                        &self,
+                        __serializer: __S,
+                    ) -> _serde::__private::Result<__S::Ok, __S::Error>
+                    where
+                        __S: _serde::Serializer,
+                    {
+                        let __serde_state = _serde::Serializer::serialize_struct(
+                            __serializer,
+                            "Schema",
+                            false as usize,
+                        )?;
+                        _serde::ser::SerializeStruct::end(__serde_state)
+                    }
+                }
+            };
+            impl Schema {
+                pub fn json_schema() -> serde_json::Map<String, serde_json::Value> {
+                    let mut schema = serde_json::Map::new();
+                    let mut properties = serde_json::Map::new();
+                    let mut required = Vec::new();
+                    schema
+                        .insert(
+                            "type".to_string(),
+                            serde_json::Value::String("object".to_string()),
+                        );
+                    schema
+                        .insert(
+                            "properties".to_string(),
+                            serde_json::Value::Object(properties),
+                        );
+                    if !required.is_empty() {
+                        schema
+                            .insert(
+                                "required".to_string(),
+                                serde_json::Value::Array(
+                                    required
+                                        .into_iter()
+                                        .map(serde_json::Value::String)
+                                        .collect(),
+                                ),
+                            );
+                    }
+                    schema
+                }
+            }
+            impl From<Schema> for SchemaRequest {
+                fn from(_: Schema) -> Self {
+                    Self
+                }
+            }
+        }
+        pub mod update {
+            use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
+            use serde::{Deserialize, Serialize};
+            use crate::core::capabilities::update::UpdateRequest;
+            impl Update {
+                /// Returns the name of the tool as a string.
+                pub fn tool_name() -> String {
+                    "update".to_string()
+                }
+                /// Constructs and returns a `rust_mcp_schema::Tool` instance.
+                ///
+                /// The tool includes the name, description, input schema, meta, and title derived from
+                /// the struct's attributes.
+                pub fn tool() -> rust_mcp_sdk::schema::Tool {
+                    let json_schema = &Update::json_schema();
+                    let required: Vec<_> = match json_schema
+                        .get("required")
+                        .and_then(|r| r.as_array())
+                    {
+                        Some(arr) => {
+                            arr.iter()
+                                .filter_map(|item| item.as_str().map(String::from))
+                                .collect()
+                        }
+                        None => Vec::new(),
+                    };
+                    let properties: Option<
+                        std::collections::HashMap<
+                            String,
+                            serde_json::Map<String, serde_json::Value>,
+                        >,
+                    > = json_schema
+                        .get("properties")
+                        .and_then(|v| v.as_object())
+                        .map(|properties| {
+                            properties
+                                .iter()
+                                .filter_map(|(key, value)| {
+                                    serde_json::to_value(value)
+                                        .ok()
+                                        .and_then(|v| {
+                                            if let serde_json::Value::Object(obj) = v {
+                                                Some(obj)
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .map(|obj| (key.to_string(), obj))
+                                })
+                                .collect()
+                        });
+                    rust_mcp_sdk::schema::Tool {
+                        name: "update".to_string(),
+                        description: Some(
+                            "Calls the update function in a Crux app".to_string(),
+                        ),
+                        output_schema: None,
+                        title: None,
+                        meta: None,
+                        annotations: Some(rust_mcp_sdk::schema::ToolAnnotations {
+                            destructive_hint: Some(false),
+                            idempotent_hint: Some(false),
+                            open_world_hint: Some(false),
+                            read_only_hint: Some(false),
+                            title: None,
+                        }),
+                        input_schema: rust_mcp_sdk::schema::ToolInputSchema::new(
+                            required,
+                            properties,
+                        ),
+                    }
+                }
+            }
+            pub struct Update {
+                pub data: String,
+            }
+            #[automatically_derived]
+            impl ::core::fmt::Debug for Update {
+                #[inline]
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                    ::core::fmt::Formatter::debug_struct_field1_finish(
+                        f,
+                        "Update",
+                        "data",
+                        &&self.data,
+                    )
+                }
+            }
+            #[doc(hidden)]
+            #[allow(
+                non_upper_case_globals,
+                unused_attributes,
+                unused_qualifications,
+                clippy::absolute_paths,
+            )]
+            const _: () = {
+                #[allow(unused_extern_crates, clippy::useless_attribute)]
+                extern crate serde as _serde;
+                #[automatically_derived]
+                impl<'de> _serde::Deserialize<'de> for Update {
+                    fn deserialize<__D>(
+                        __deserializer: __D,
+                    ) -> _serde::__private::Result<Self, __D::Error>
+                    where
+                        __D: _serde::Deserializer<'de>,
+                    {
+                        #[allow(non_camel_case_types)]
+                        #[doc(hidden)]
+                        enum __Field {
+                            __field0,
+                            __ignore,
+                        }
+                        #[doc(hidden)]
+                        struct __FieldVisitor;
+                        #[automatically_derived]
+                        impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                            type Value = __Field;
+                            fn expecting(
+                                &self,
+                                __formatter: &mut _serde::__private::Formatter,
+                            ) -> _serde::__private::fmt::Result {
+                                _serde::__private::Formatter::write_str(
+                                    __formatter,
+                                    "field identifier",
+                                )
+                            }
+                            fn visit_u64<__E>(
+                                self,
+                                __value: u64,
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    0u64 => _serde::__private::Ok(__Field::__field0),
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                            fn visit_str<__E>(
+                                self,
+                                __value: &str,
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    "data" => _serde::__private::Ok(__Field::__field0),
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                            fn visit_bytes<__E>(
+                                self,
+                                __value: &[u8],
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    b"data" => _serde::__private::Ok(__Field::__field0),
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                        }
+                        #[automatically_derived]
+                        impl<'de> _serde::Deserialize<'de> for __Field {
+                            #[inline]
+                            fn deserialize<__D>(
+                                __deserializer: __D,
+                            ) -> _serde::__private::Result<Self, __D::Error>
+                            where
+                                __D: _serde::Deserializer<'de>,
+                            {
+                                _serde::Deserializer::deserialize_identifier(
+                                    __deserializer,
+                                    __FieldVisitor,
+                                )
+                            }
+                        }
+                        #[doc(hidden)]
+                        struct __Visitor<'de> {
+                            marker: _serde::__private::PhantomData<Update>,
+                            lifetime: _serde::__private::PhantomData<&'de ()>,
+                        }
+                        #[automatically_derived]
+                        impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                            type Value = Update;
+                            fn expecting(
+                                &self,
+                                __formatter: &mut _serde::__private::Formatter,
+                            ) -> _serde::__private::fmt::Result {
+                                _serde::__private::Formatter::write_str(
+                                    __formatter,
+                                    "struct Update",
+                                )
+                            }
+                            #[inline]
+                            fn visit_seq<__A>(
+                                self,
+                                mut __seq: __A,
+                            ) -> _serde::__private::Result<Self::Value, __A::Error>
+                            where
+                                __A: _serde::de::SeqAccess<'de>,
+                            {
+                                let __field0 = match _serde::de::SeqAccess::next_element::<
+                                    String,
+                                >(&mut __seq)? {
+                                    _serde::__private::Some(__value) => __value,
+                                    _serde::__private::None => {
+                                        return _serde::__private::Err(
+                                            _serde::de::Error::invalid_length(
+                                                0usize,
+                                                &"struct Update with 1 element",
+                                            ),
+                                        );
+                                    }
+                                };
+                                _serde::__private::Ok(Update { data: __field0 })
+                            }
+                            #[inline]
+                            fn visit_map<__A>(
+                                self,
+                                mut __map: __A,
+                            ) -> _serde::__private::Result<Self::Value, __A::Error>
+                            where
+                                __A: _serde::de::MapAccess<'de>,
+                            {
+                                let mut __field0: _serde::__private::Option<String> = _serde::__private::None;
+                                while let _serde::__private::Some(__key) = _serde::de::MapAccess::next_key::<
+                                    __Field,
+                                >(&mut __map)? {
+                                    match __key {
+                                        __Field::__field0 => {
+                                            if _serde::__private::Option::is_some(&__field0) {
+                                                return _serde::__private::Err(
+                                                    <__A::Error as _serde::de::Error>::duplicate_field("data"),
+                                                );
+                                            }
+                                            __field0 = _serde::__private::Some(
+                                                _serde::de::MapAccess::next_value::<String>(&mut __map)?,
+                                            );
+                                        }
+                                        _ => {
+                                            let _ = _serde::de::MapAccess::next_value::<
+                                                _serde::de::IgnoredAny,
+                                            >(&mut __map)?;
+                                        }
+                                    }
+                                }
+                                let __field0 = match __field0 {
+                                    _serde::__private::Some(__field0) => __field0,
+                                    _serde::__private::None => {
+                                        _serde::__private::de::missing_field("data")?
+                                    }
+                                };
+                                _serde::__private::Ok(Update { data: __field0 })
+                            }
+                        }
+                        #[doc(hidden)]
+                        const FIELDS: &'static [&'static str] = &["data"];
+                        _serde::Deserializer::deserialize_struct(
+                            __deserializer,
+                            "Update",
+                            FIELDS,
+                            __Visitor {
+                                marker: _serde::__private::PhantomData::<Update>,
+                                lifetime: _serde::__private::PhantomData,
+                            },
+                        )
+                    }
+                }
+            };
+            #[doc(hidden)]
+            #[allow(
+                non_upper_case_globals,
+                unused_attributes,
+                unused_qualifications,
+                clippy::absolute_paths,
+            )]
+            const _: () = {
+                #[allow(unused_extern_crates, clippy::useless_attribute)]
+                extern crate serde as _serde;
+                #[automatically_derived]
+                impl _serde::Serialize for Update {
+                    fn serialize<__S>(
+                        &self,
+                        __serializer: __S,
+                    ) -> _serde::__private::Result<__S::Ok, __S::Error>
+                    where
+                        __S: _serde::Serializer,
+                    {
+                        let mut __serde_state = _serde::Serializer::serialize_struct(
+                            __serializer,
+                            "Update",
+                            false as usize + 1,
+                        )?;
+                        _serde::ser::SerializeStruct::serialize_field(
+                            &mut __serde_state,
+                            "data",
+                            &self.data,
+                        )?;
+                        _serde::ser::SerializeStruct::end(__serde_state)
+                    }
+                }
+            };
+            impl Update {
+                pub fn json_schema() -> serde_json::Map<String, serde_json::Value> {
+                    let mut schema = serde_json::Map::new();
+                    let mut properties = serde_json::Map::new();
+                    let mut required = Vec::new();
+                    properties
+                        .insert(
+                            "data".to_string(),
+                            serde_json::Value::Object({
+                                let mut map = serde_json::Map::new();
+                                map.insert(
+                                    "type".to_string(),
+                                    serde_json::Value::String("string".to_string()),
+                                );
+                                map
+                            }),
+                        );
+                    required.push("data".to_string());
+                    schema
+                        .insert(
+                            "type".to_string(),
+                            serde_json::Value::String("object".to_string()),
+                        );
+                    schema
+                        .insert(
+                            "properties".to_string(),
+                            serde_json::Value::Object(properties),
+                        );
+                    if !required.is_empty() {
+                        schema
+                            .insert(
+                                "required".to_string(),
+                                serde_json::Value::Array(
+                                    required
+                                        .into_iter()
+                                        .map(serde_json::Value::String)
+                                        .collect(),
+                                ),
+                            );
+                    }
+                    schema
+                }
+            }
+            impl From<Update> for UpdateRequest {
+                fn from(update: Update) -> Self {
+                    Self {
+                        data: update.data.into_bytes(),
+                    }
+                }
+            }
+        }
+        pub mod view {
+            use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
+            use serde::{Deserialize, Serialize};
+            use crate::core::capabilities::view::ViewRequest;
+            impl View {
+                /// Returns the name of the tool as a string.
+                pub fn tool_name() -> String {
+                    "view".to_string()
+                }
+                /// Constructs and returns a `rust_mcp_schema::Tool` instance.
+                ///
+                /// The tool includes the name, description, input schema, meta, and title derived from
+                /// the struct's attributes.
+                pub fn tool() -> rust_mcp_sdk::schema::Tool {
+                    let json_schema = &View::json_schema();
+                    let required: Vec<_> = match json_schema
+                        .get("required")
+                        .and_then(|r| r.as_array())
+                    {
+                        Some(arr) => {
+                            arr.iter()
+                                .filter_map(|item| item.as_str().map(String::from))
+                                .collect()
+                        }
+                        None => Vec::new(),
+                    };
+                    let properties: Option<
+                        std::collections::HashMap<
+                            String,
+                            serde_json::Map<String, serde_json::Value>,
+                        >,
+                    > = json_schema
+                        .get("properties")
+                        .and_then(|v| v.as_object())
+                        .map(|properties| {
+                            properties
+                                .iter()
+                                .filter_map(|(key, value)| {
+                                    serde_json::to_value(value)
+                                        .ok()
+                                        .and_then(|v| {
+                                            if let serde_json::Value::Object(obj) = v {
+                                                Some(obj)
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .map(|obj| (key.to_string(), obj))
+                                })
+                                .collect()
+                        });
+                    rust_mcp_sdk::schema::Tool {
+                        name: "view".to_string(),
+                        description: Some(
+                            "Gets the ViewModel by calling the view function in a Crux app"
+                                .to_string(),
+                        ),
+                        output_schema: None,
+                        title: None,
+                        meta: None,
+                        annotations: Some(rust_mcp_sdk::schema::ToolAnnotations {
+                            destructive_hint: Some(false),
+                            idempotent_hint: Some(false),
+                            open_world_hint: Some(false),
+                            read_only_hint: Some(true),
+                            title: None,
+                        }),
+                        input_schema: rust_mcp_sdk::schema::ToolInputSchema::new(
+                            required,
+                            properties,
+                        ),
+                    }
+                }
+            }
+            pub struct View {}
+            #[automatically_derived]
+            impl ::core::fmt::Debug for View {
+                #[inline]
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                    ::core::fmt::Formatter::write_str(f, "View")
+                }
+            }
+            #[doc(hidden)]
+            #[allow(
+                non_upper_case_globals,
+                unused_attributes,
+                unused_qualifications,
+                clippy::absolute_paths,
+            )]
+            const _: () = {
+                #[allow(unused_extern_crates, clippy::useless_attribute)]
+                extern crate serde as _serde;
+                #[automatically_derived]
+                impl<'de> _serde::Deserialize<'de> for View {
+                    fn deserialize<__D>(
+                        __deserializer: __D,
+                    ) -> _serde::__private::Result<Self, __D::Error>
+                    where
+                        __D: _serde::Deserializer<'de>,
+                    {
+                        #[allow(non_camel_case_types)]
+                        #[doc(hidden)]
+                        enum __Field {
+                            __ignore,
+                        }
+                        #[doc(hidden)]
+                        struct __FieldVisitor;
+                        #[automatically_derived]
+                        impl<'de> _serde::de::Visitor<'de> for __FieldVisitor {
+                            type Value = __Field;
+                            fn expecting(
+                                &self,
+                                __formatter: &mut _serde::__private::Formatter,
+                            ) -> _serde::__private::fmt::Result {
+                                _serde::__private::Formatter::write_str(
+                                    __formatter,
+                                    "field identifier",
+                                )
+                            }
+                            fn visit_u64<__E>(
+                                self,
+                                __value: u64,
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                            fn visit_str<__E>(
+                                self,
+                                __value: &str,
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                            fn visit_bytes<__E>(
+                                self,
+                                __value: &[u8],
+                            ) -> _serde::__private::Result<Self::Value, __E>
+                            where
+                                __E: _serde::de::Error,
+                            {
+                                match __value {
+                                    _ => _serde::__private::Ok(__Field::__ignore),
+                                }
+                            }
+                        }
+                        #[automatically_derived]
+                        impl<'de> _serde::Deserialize<'de> for __Field {
+                            #[inline]
+                            fn deserialize<__D>(
+                                __deserializer: __D,
+                            ) -> _serde::__private::Result<Self, __D::Error>
+                            where
+                                __D: _serde::Deserializer<'de>,
+                            {
+                                _serde::Deserializer::deserialize_identifier(
+                                    __deserializer,
+                                    __FieldVisitor,
+                                )
+                            }
+                        }
+                        #[doc(hidden)]
+                        struct __Visitor<'de> {
+                            marker: _serde::__private::PhantomData<View>,
+                            lifetime: _serde::__private::PhantomData<&'de ()>,
+                        }
+                        #[automatically_derived]
+                        impl<'de> _serde::de::Visitor<'de> for __Visitor<'de> {
+                            type Value = View;
+                            fn expecting(
+                                &self,
+                                __formatter: &mut _serde::__private::Formatter,
+                            ) -> _serde::__private::fmt::Result {
+                                _serde::__private::Formatter::write_str(
+                                    __formatter,
+                                    "struct View",
+                                )
+                            }
+                            #[inline]
+                            fn visit_seq<__A>(
+                                self,
+                                _: __A,
+                            ) -> _serde::__private::Result<Self::Value, __A::Error>
+                            where
+                                __A: _serde::de::SeqAccess<'de>,
+                            {
+                                _serde::__private::Ok(View {})
+                            }
+                            #[inline]
+                            fn visit_map<__A>(
+                                self,
+                                mut __map: __A,
+                            ) -> _serde::__private::Result<Self::Value, __A::Error>
+                            where
+                                __A: _serde::de::MapAccess<'de>,
+                            {
+                                while let _serde::__private::Some(__key) = _serde::de::MapAccess::next_key::<
+                                    __Field,
+                                >(&mut __map)? {
+                                    match __key {
+                                        _ => {
+                                            let _ = _serde::de::MapAccess::next_value::<
+                                                _serde::de::IgnoredAny,
+                                            >(&mut __map)?;
+                                        }
+                                    }
+                                }
+                                _serde::__private::Ok(View {})
+                            }
+                        }
+                        #[doc(hidden)]
+                        const FIELDS: &'static [&'static str] = &[];
+                        _serde::Deserializer::deserialize_struct(
+                            __deserializer,
+                            "View",
+                            FIELDS,
+                            __Visitor {
+                                marker: _serde::__private::PhantomData::<View>,
+                                lifetime: _serde::__private::PhantomData,
+                            },
+                        )
+                    }
+                }
+            };
+            #[doc(hidden)]
+            #[allow(
+                non_upper_case_globals,
+                unused_attributes,
+                unused_qualifications,
+                clippy::absolute_paths,
+            )]
+            const _: () = {
+                #[allow(unused_extern_crates, clippy::useless_attribute)]
+                extern crate serde as _serde;
+                #[automatically_derived]
+                impl _serde::Serialize for View {
+                    fn serialize<__S>(
+                        &self,
+                        __serializer: __S,
+                    ) -> _serde::__private::Result<__S::Ok, __S::Error>
+                    where
+                        __S: _serde::Serializer,
+                    {
+                        let __serde_state = _serde::Serializer::serialize_struct(
+                            __serializer,
+                            "View",
+                            false as usize,
+                        )?;
+                        _serde::ser::SerializeStruct::end(__serde_state)
+                    }
+                }
+            };
+            impl View {
+                pub fn json_schema() -> serde_json::Map<String, serde_json::Value> {
+                    let mut schema = serde_json::Map::new();
+                    let mut properties = serde_json::Map::new();
+                    let mut required = Vec::new();
+                    schema
+                        .insert(
+                            "type".to_string(),
+                            serde_json::Value::String("object".to_string()),
+                        );
+                    schema
+                        .insert(
+                            "properties".to_string(),
+                            serde_json::Value::Object(properties),
+                        );
+                    if !required.is_empty() {
+                        schema
+                            .insert(
+                                "required".to_string(),
+                                serde_json::Value::Array(
+                                    required
+                                        .into_iter()
+                                        .map(serde_json::Value::String)
+                                        .collect(),
+                                ),
+                            );
+                    }
+                    schema
+                }
+            }
+            impl From<View> for ViewRequest {
+                fn from(_: View) -> Self {
+                    Self
+                }
+            }
+        }
+        use resolve::Resolve;
+        use schema::Schema;
+        use update::Update;
+        use view::View;
+        use crate::core::app::Event;
+        pub enum MyTools {
+            Schema(Schema),
+            Update(Update),
+            Resolve(Resolve),
+            View(View),
+        }
+        #[automatically_derived]
+        impl ::core::fmt::Debug for MyTools {
+            #[inline]
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                match self {
+                    MyTools::Schema(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "Schema",
+                            &__self_0,
+                        )
+                    }
+                    MyTools::Update(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "Update",
+                            &__self_0,
+                        )
+                    }
+                    MyTools::Resolve(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "Resolve",
+                            &__self_0,
+                        )
+                    }
+                    MyTools::View(__self_0) => {
+                        ::core::fmt::Formatter::debug_tuple_field1_finish(
+                            f,
+                            "View",
+                            &__self_0,
+                        )
+                    }
+                }
+            }
+        }
+        /// Returns the name of the tool as a String
+        impl MyTools {
+            pub fn tool_name(&self) -> String {
+                match self {
+                    MyTools::Schema(_) => Schema::tool_name(),
+                    MyTools::Update(_) => Update::tool_name(),
+                    MyTools::Resolve(_) => Resolve::tool_name(),
+                    MyTools::View(_) => View::tool_name(),
+                }
+            }
+            /// Returns a vector containing instances of all supported tools
+            pub fn tools() -> Vec<rust_mcp_sdk::schema::Tool> {
+                <[_]>::into_vec(
+                    ::alloc::boxed::box_new([
+                        Schema::tool(),
+                        Update::tool(),
+                        Resolve::tool(),
+                        View::tool(),
+                    ]),
+                )
+            }
+            #[deprecated(since = "0.2.0", note = "Use `tools()` instead.")]
+            pub fn get_tools() -> Vec<rust_mcp_sdk::schema::Tool> {
+                <[_]>::into_vec(
+                    ::alloc::boxed::box_new([
+                        Schema::tool(),
+                        Update::tool(),
+                        Resolve::tool(),
+                        View::tool(),
+                    ]),
+                )
+            }
+        }
+        impl TryFrom<rust_mcp_sdk::schema::CallToolRequestParams> for MyTools {
+            type Error = rust_mcp_sdk::schema::schema_utils::CallToolError;
+            /// Attempts to convert a tool request into the appropriate tool variant
+            fn try_from(
+                value: rust_mcp_sdk::schema::CallToolRequestParams,
+            ) -> Result<Self, Self::Error> {
+                let v = serde_json::to_value(value.arguments.unwrap())
+                    .map_err(rust_mcp_sdk::schema::schema_utils::CallToolError::new)?;
+                match value.name {
+                    name if name == Schema::tool_name().as_str() => {
+                        Ok(
+                            Self::Schema(
+                                serde_json::from_value(v)
+                                    .map_err(
+                                        rust_mcp_sdk::schema::schema_utils::CallToolError::new,
+                                    )?,
+                            ),
+                        )
+                    }
+                    name if name == Update::tool_name().as_str() => {
+                        Ok(
+                            Self::Update(
+                                serde_json::from_value(v)
+                                    .map_err(
+                                        rust_mcp_sdk::schema::schema_utils::CallToolError::new,
+                                    )?,
+                            ),
+                        )
+                    }
+                    name if name == Resolve::tool_name().as_str() => {
+                        Ok(
+                            Self::Resolve(
+                                serde_json::from_value(v)
+                                    .map_err(
+                                        rust_mcp_sdk::schema::schema_utils::CallToolError::new,
+                                    )?,
+                            ),
+                        )
+                    }
+                    name if name == View::tool_name().as_str() => {
+                        Ok(
+                            Self::View(
+                                serde_json::from_value(v)
+                                    .map_err(
+                                        rust_mcp_sdk::schema::schema_utils::CallToolError::new,
+                                    )?,
+                            ),
+                        )
+                    }
+                    _ => {
+                        Err(
+                            rust_mcp_sdk::schema::schema_utils::CallToolError::unknown_tool(
+                                value.name.to_string(),
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+        impl From<MyTools> for Event {
+            fn from(tool: MyTools) -> Self {
+                match tool {
+                    MyTools::Schema(params) => Event::Schema(params.into()),
+                    MyTools::Update(params) => Event::Update(params.into()),
+                    MyTools::Resolve(params) => Event::Resolve(params.into()),
+                    MyTools::View(params) => Event::View(params.into()),
+                }
+            }
+        }
+    }
+}
+pub use error::{Error, Result};
+fn main() -> SdkResult<()> {
+    let body = async {
+        let server_details = InitializeResult {
+            server_info: Implementation {
+                name: "Crux app MCP Server".to_string(),
+                version: "0.1.0".to_string(),
+                title: None,
+            },
+            capabilities: ServerCapabilities {
+                tools: Some(ServerCapabilitiesTools {
+                    list_changed: None,
+                }),
+                ..Default::default()
+            },
+            meta: None,
+            instructions: Some("server instructions...".to_string()),
+            protocol_version: LATEST_PROTOCOL_VERSION.to_string(),
+        };
+        let mut host = Host::default();
+        host.load().expect("failed to load guest");
+        let core = Core::new(host);
+        let server = server_runtime::create_server(
+            server_details,
+            StdioTransport::new(TransportOptions::default())?,
+            MyServerHandler::new(core),
+        );
+        server.start().await
+    };
+    #[allow(
+        clippy::expect_used,
+        clippy::diverging_sub_expression,
+        clippy::needless_return
+    )]
+    {
+        return tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("Failed building the Runtime")
+            .block_on(body);
+    }
+}


### PR DESCRIPTION
This uses wasmtime bindgen to make it easier to instantiate the resource that is now exported by the guest component.